### PR TITLE
Backport LLM judge improvements from ollama37

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,8 +182,10 @@ export const CONFIG = {
   llm: {
     defaultUrl: 'http://localhost:11434',  // ← Your Ollama URL
     defaultModel: 'llama3:8b',             // ← Your model
-    batchSize: 5,
     timeout: 300000,
+    stdoutLimit: 1000,                     // ← Max stdout chars per step in prompt
+    stderrLimit: 500,                      // ← Max stderr chars per step in prompt
+    logsLimit: 3000,                       // ← Max container log chars in prompt
   },
 };
 

--- a/cicd/tests/src/config.ts
+++ b/cicd/tests/src/config.ts
@@ -28,8 +28,10 @@ export const CONFIG = {
   llm: {
     defaultUrl: 'http://localhost:11434',
     defaultModel: 'llama3:8b',
-    batchSize: 5,
     timeout: 300000,
+    stdoutLimit: 1000,
+    stderrLimit: 500,
+    logsLimit: 3000,
   },
   
   // Log collection settings

--- a/cicd/tests/src/judge/llm-judge.ts
+++ b/cicd/tests/src/judge/llm-judge.ts
@@ -3,6 +3,9 @@
  *
  * Uses a language model to evaluate test execution logs against criteria.
  * Catches silent failures that exit code checking misses.
+ *
+ * Judges one test at a time with structured JSON prompts and Ollama JSON mode
+ * for reliable parsing. Includes observability logging for debugging CI failures.
  */
 
 import axios from 'axios';
@@ -12,7 +15,6 @@ import { CONFIG } from '../config.js';
 export class LLMJudge {
   private ollamaUrl: string;
   private model: string;
-  private batchSize: number;
 
   constructor(
     ollamaUrl: string = CONFIG.llm.defaultUrl,
@@ -20,7 +22,6 @@ export class LLMJudge {
   ) {
     this.ollamaUrl = ollamaUrl;
     this.model = model;
-    this.batchSize = CONFIG.llm.batchSize;
   }
 
   async isAvailable(): Promise<boolean> {
@@ -34,90 +35,81 @@ export class LLMJudge {
     }
   }
 
-  private formatDuration(ms: number): string {
-    if (ms < 1000) return `${ms}ms`;
-    if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
-    return `${(ms / 60000).toFixed(1)}min`;
+  /**
+   * Truncate a string to a maximum length.
+   */
+  private truncate(text: string, limit: number): string {
+    if (text.length <= limit) return text;
+    return text.substring(0, limit) + '... (truncated)';
   }
 
-  private buildPrompt(results: TestResult[]): string {
-    const testsSection = results
-      .map((r, i) => {
-        const stepsSummary = r.steps
-          .map((step, j) => {
-            const status = step.exitCode === 0 ? 'PASS' : 'FAIL';
-            const stepTimeout = r.testCase.steps[j]?.timeout || r.testCase.timeout;
-            return `  ${j + 1}. "${step.name}" - ${status} (exit: ${step.exitCode}, duration: ${this.formatDuration(step.duration)}, timeout: ${this.formatDuration(stepTimeout)})`;
-          })
-          .join('\n');
+  /**
+   * Build structured JSON prompt for LLM evaluation of a single test.
+   */
+  private buildPrompt(result: TestResult): string {
+    const r = result;
 
-        const allStepsPassed = r.steps.every((s) => s.exitCode === 0);
-        const simpleResult = allStepsPassed ? 'PASS' : 'FAIL';
+    const steps = r.steps.map((step, j) => {
+      const stepDef = r.testCase.steps[j];
+      return {
+        name: step.name,
+        command: step.command.trim(),
+        exit_code: step.exitCode,
+        duration_ms: step.duration,
+        timeout_ms: stepDef?.timeout || r.testCase.timeout,
+        stdout: this.truncate(step.stdout, CONFIG.llm.stdoutLimit),
+        stderr: this.truncate(step.stderr, CONFIG.llm.stderrLimit),
+      };
+    });
 
-        const timeoutMs = r.testCase.timeout;
-        const withinTimeout = r.totalDuration < timeoutMs;
-        const timeoutNote = withinTimeout
-          ? `Total duration ${this.formatDuration(r.totalDuration)} is within timeout of ${this.formatDuration(timeoutMs)}.`
-          : `Total duration ${this.formatDuration(r.totalDuration)} exceeded timeout of ${this.formatDuration(timeoutMs)}.`;
+    const promptData = {
+      role: `You are a test result evaluator for ${CONFIG.projectName}. Analyze the test execution data and determine if the test passed or failed.`,
+      rules: [
+        'Check step stdout for error responses (e.g. {"error":"..."} means FAIL)',
+        'Errors with exit code 0 are still FAIL',
+        'For AI-generated text, accept reasonable variations',
+        'Long durations within timeout are acceptable',
+        'Focus on semantic correctness, not formatting differences',
+      ],
+      test: {
+        id: r.testCase.id,
+        name: r.testCase.name,
+        suite: r.testCase.suite,
+        goal: r.testCase.goal || r.testCase.name,
+        criteria: r.testCase.criteria,
+        timeout_ms: r.testCase.timeout,
+        duration_ms: r.totalDuration,
+      },
+      steps,
+      container_logs: this.truncate(r.logs, CONFIG.llm.logsLimit),
+      respond: {
+        format: 'Respond with a single JSON object',
+        fields: {
+          testId: r.testCase.id,
+          pass: 'true if test meets all criteria, false otherwise',
+          reason: 'Brief explanation of your verdict',
+          evidence: 'Required if pass is false — the exact stdout content or log line that caused failure',
+        },
+      },
+    };
 
-        const logTruncateLimit = 3000;
-        const truncatedLogs =
-          r.logs.length > logTruncateLimit
-            ? r.logs.substring(0, logTruncateLimit) + '\n... (truncated)'
-            : r.logs;
+    const prompt = JSON.stringify(promptData, null, 2);
 
-        return `
-### Test ${i + 1}: ${r.testCase.id} - ${r.testCase.name}
+    // Log prompt stats
+    const totalStdout = r.steps.reduce((sum, s) => sum + s.stdout.length, 0);
+    const totalStderr = r.steps.reduce((sum, s) => sum + s.stderr.length, 0);
+    process.stderr.write(`  [LLM] Prompt for ${r.testCase.id}: logs ${r.logs.length} chars, stdout ${totalStdout} chars, stderr ${totalStderr} chars\n`);
+    process.stderr.write(`  [LLM] Prompt size: ${prompt.length} chars\n`);
 
-**Criteria:**
-${r.testCase.criteria}
-
-**Step Results:**
-${stepsSummary}
-
-**Simple Judge Result:** ${simpleResult} (${allStepsPassed ? 'all steps exit code 0' : 'some steps failed'})
-
-**Timing:** ${timeoutNote}
-
-**Execution Logs:**
-\`\`\`
-${truncatedLogs}
-\`\`\`
-`;
-      })
-      .join('\n---\n');
-
-    return `You are a test evaluation judge for ${CONFIG.projectName}.
-
-Analyze the following test results and determine if each test passed or failed based on the criteria provided.
-
-For each test, examine:
-1. The expected criteria
-2. The actual execution logs (stdout, stderr, exit codes)
-3. Whether the output meets the criteria
-
-${testsSection}
-
-Respond with a JSON array containing one object per test:
-[
-  {"testId": "TC-XXX-001", "pass": true, "reason": "Brief explanation"},
-  {"testId": "TC-XXX-002", "pass": false, "reason": "Brief explanation", "evidence": "The actual log line that caused failure"}
-]
-
-When marking a test as FAIL, you MUST provide the "evidence" field with the exact log line content that caused the failure.
-
-Important:
-- For AI-generated text, accept reasonable variations
-- For build/runtime tests, check exit codes AND absence of error messages in logs
-- If logs show errors even with exit code 0, the test should FAIL
-- Long durations are acceptable if within the configured timeout
-- Be lenient with formatting differences, focus on semantic correctness
-
-Respond ONLY with the JSON array, no other text.`;
+    return prompt;
   }
 
-  private async judgeBatch(results: TestResult[]): Promise<Judgment[]> {
-    const prompt = this.buildPrompt(results);
+  /**
+   * Judge a single test result.
+   */
+  private async judgeOne(result: TestResult): Promise<Judgment> {
+    const prompt = this.buildPrompt(result);
+    const testId = result.testCase.id;
 
     const response = await axios.post(
       `${this.ollamaUrl}/api/generate`,
@@ -125,9 +117,10 @@ Respond ONLY with the JSON array, no other text.`;
         model: this.model,
         prompt,
         stream: false,
+        format: 'json',
         options: {
           temperature: 0.1,
-          num_predict: 1000,
+          num_predict: 1024,
         },
       },
       {
@@ -136,55 +129,85 @@ Respond ONLY with the JSON array, no other text.`;
     );
 
     const responseText = response.data.response;
+    const promptTokens = response.data.prompt_eval_count ?? '?';
+    const responseTokens = response.data.eval_count ?? '?';
+    process.stderr.write(`  [LLM] Tokens for ${testId}: prompt=${promptTokens}, response=${responseTokens}\n`);
 
-    const jsonMatch = responseText.match(/\[[\s\S]*\]/);
-    if (!jsonMatch) {
-      throw new Error('No JSON array found in LLM response');
+    // Handle empty response
+    if (!responseText) {
+      process.stderr.write(`  [LLM] WARNING: Empty response for ${testId}\n`);
+      return {
+        testId,
+        pass: false,
+        reason: 'LLM returned empty response',
+      };
     }
 
+    process.stderr.write(`  [LLM] Raw response for ${testId} (${responseText.length} chars): ${responseText.substring(0, 500)}\n`);
+
     try {
-      const judgments = JSON.parse(jsonMatch[0]) as Judgment[];
+      const judgment = JSON.parse(responseText) as Judgment;
 
-      const resultIds = results.map((r) => r.testCase.id);
-      const judgedIds = new Set(judgments.map((j) => j.testId));
-
-      for (const id of resultIds) {
-        if (!judgedIds.has(id)) {
-          judgments.push({
-            testId: id,
-            pass: false,
-            reason: 'No judgment provided by LLM',
-          });
-        }
+      // Validate testId matches
+      if (judgment.testId !== testId) {
+        process.stderr.write(`  [LLM] WARNING: Response testId "${judgment.testId}" doesn't match expected "${testId}"\n`);
+        judgment.testId = testId;
       }
 
-      return judgments;
+      // Coerce string "true"/"false" to boolean (LLMs often return strings)
+      if (typeof judgment.pass === 'string') {
+        judgment.pass = (judgment.pass as unknown as string).toLowerCase() === 'true';
+      }
+
+      // Validate required fields
+      if (typeof judgment.pass !== 'boolean') {
+        process.stderr.write(`  [LLM] WARNING: Response missing "pass" field for ${testId}\n`);
+        return {
+          testId,
+          pass: false,
+          reason: `LLM response missing "pass" field: ${responseText.substring(0, 200)}`,
+        };
+      }
+
+      if (!judgment.reason) {
+        judgment.reason = judgment.pass ? 'Passed (no reason provided)' : 'Failed (no reason provided)';
+      }
+
+      return judgment;
     } catch {
-      throw new Error(`Failed to parse LLM response: ${responseText.substring(0, 200)}`);
+      process.stderr.write(`  [LLM] WARNING: Failed to parse JSON for ${testId}\n`);
+      process.stderr.write(`  [LLM] Full response: ${responseText}\n`);
+      return {
+        testId,
+        pass: false,
+        reason: `Failed to parse LLM response: ${responseText.substring(0, 200)}`,
+      };
     }
   }
 
+  /**
+   * Judge all test results, one at a time.
+   */
   async judgeResults(results: TestResult[]): Promise<Judgment[]> {
     const allJudgments: Judgment[] = [];
 
-    for (let i = 0; i < results.length; i += this.batchSize) {
-      const batch = results.slice(i, i + this.batchSize);
+    for (let i = 0; i < results.length; i++) {
+      const result = results[i];
       process.stderr.write(
-        `  [LLM] Judging batch ${Math.floor(i / this.batchSize) + 1}/${Math.ceil(results.length / this.batchSize)}...\n`
+        `  [LLM] Judging ${i + 1}/${results.length}: ${result.testCase.id}...\n`
       );
 
       try {
-        const judgments = await this.judgeBatch(batch);
-        allJudgments.push(...judgments);
+        const judgment = await this.judgeOne(result);
+        allJudgments.push(judgment);
+        process.stderr.write(`  [LLM] ${result.testCase.id}: ${judgment.pass ? 'PASS' : 'FAIL'} — ${judgment.reason}\n`);
       } catch (error) {
-        process.stderr.write(`  [LLM] Failed to judge batch: ${error}\n`);
-        for (const r of batch) {
-          allJudgments.push({
-            testId: r.testCase.id,
-            pass: false,
-            reason: 'LLM judgment failed: ' + String(error),
-          });
-        }
+        process.stderr.write(`  [LLM] Failed to judge ${result.testCase.id}: ${error}\n`);
+        allJudgments.push({
+          testId: result.testCase.id,
+          pass: false,
+          reason: 'LLM judgment failed: ' + String(error),
+        });
       }
     }
 

--- a/cicd/tests/src/types.ts
+++ b/cicd/tests/src/types.ts
@@ -42,6 +42,8 @@ export interface TestCase {
   steps: TestStep[];
   /** Human-readable criteria for LLM judge evaluation */
   criteria: string;
+  /** Short goal statement for LLM judge context (optional) */
+  goal?: string;
 }
 
 // ============================================


### PR DESCRIPTION
## Summary

- Replace batch judging with one-at-a-time evaluation (batching silently dropped results)
- Include step stdout/stderr in LLM prompt (was missing, causing false positives)
- Switch to Ollama JSON mode + structured JSON prompt (was fragile regex extraction)
- Add observability logging: prompt size, token counts, raw response, warnings
- Add optional `goal` field to TestCase for better LLM context
- Handle empty/malformed responses and coerce string booleans gracefully

## Test plan

- [ ] Verify template installs cleanly into a fresh project (`make install`)
- [ ] Run test suite with `--no-llm` to confirm simple judge still works
- [ ] Run test suite with LLM judge enabled against a local Ollama instance
- [ ] Verify stderr shows prompt size, token counts, and raw response logging

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)