### PR TITLE
Add Claude commands for CI test workflow

### DIFF
--- a/.claude/commands/add-tool.md
+++ b/.claude/commands/add-tool.md
@@ -1,0 +1,209 @@
+# Add New MCP Tool
+
+Add a new MCP tool to this server following established patterns and guidelines.
+
+## Process Overview
+
+This command guides you through a systematic process to:
+1. Analyze API behavior to understand the operation
+2. Study existing codebase patterns
+3. Implement consistent code following project guidelines
+4. Review for compliance with project standards
+
+---
+
+## Phase 1: Understand the Project
+
+### Study Project Guidelines
+- Read the project's CLAUDE.md file to understand architectural patterns
+- Identify the distinction between operation types (read-only vs async)
+- Review parameter ordering conventions
+- Understand error handling patterns
+
+### Study Existing Implementation
+- Search for similar existing tools in the services layer
+- Examine how existing tools are registered in the MCP server
+- Review how existing tools handle errors
+- Identify polling and retry patterns for async operations
+
+**Action:** Use file search tools to locate similar implementations before writing any code.
+
+---
+
+## Phase 2: Gather Requirements
+
+### Understand the Operation
+Ask for or determine:
+- HTTP method and endpoint (or equivalent operation)
+- Request/response structure
+- Whether response includes async operation indicators
+- Business purpose of the operation
+
+### Determine Operation Type
+
+| Type | Characteristics | Template |
+|------|----------------|----------|
+| **Read-only query** | GET/query, no side effects | No retry params, return directly |
+| **Async with polling** | Create/delete/update, returns tracking ID | `maxRetries`, `pollIntervalMs` |
+| **Conditional async** | Multi-step, some steps conditional | Spread operator with conditional |
+| **Retrieve-then-update** | GET current state, merge, PUT back | Preserve all existing fields |
+| **Type-based conditional** | Different payloads per resource type | Switch/if on type |
+| **Type-based early return** | Entirely different flows per type | Early return pattern |
+| **Optional payload** | Empty body support for PUT/POST | Conditional body construction |
+
+**Action:** Confirm operation type before proceeding.
+
+---
+
+## Phase 3: Pattern Analysis
+
+### Find the Most Similar Existing Tool
+Search the codebase for:
+- Functions with the same operation type
+- Functions calling similar API endpoints
+- Functions with matching patterns (polling, query, CRUD)
+
+### Copy the Pattern Exactly
+From the similar tool, note:
+- Parameter order and types
+- Default values
+- API URL construction
+- Request/response handling
+- Error handling structure
+- Polling logic (if async)
+
+**Action:** Read the complete implementation of the most similar tool to use as a template.
+
+---
+
+## Phase 4: Implementation Planning
+
+### Create Checklist
+Plan the implementation:
+1. Implement service layer function
+2. Register tool in MCP server
+3. Implement request handler
+4. Review against guidelines
+5. Review tool description for AI agent clarity
+
+### Identify Potential Issues
+Before coding, consider:
+- Unique aspects not covered by existing patterns
+- Data transformation needs
+- Pagination requirements
+- Authentication differences
+
+**Action:** Stop and ask questions if the operation reveals patterns not seen in existing code.
+
+---
+
+## Phase 5: Service Layer Implementation
+
+### Implement Core Function
+Follow the pattern from the most similar existing tool:
+- Use exact parameter ordering from the pattern
+- Use exact default values from the pattern
+- Copy API URL construction logic
+- Copy request structure
+- Copy error handling approach
+
+### For Async Operations
+- Copy polling loop exactly from existing async tool
+- Do not modify retry defaults without approval
+- Do not modify polling interval without approval
+- Standard defaults: `maxRetries = 5`, `pollIntervalMs = 2000`
+
+### For Read-Only Operations
+- Do not add retry parameters
+- Do not add polling logic
+- Return response data directly
+- Follow query/filter patterns if applicable
+
+---
+
+## Phase 6: MCP Tool Registration
+
+### Register Tool Schema
+- Define tool name following project naming conventions (snake_case)
+- Write clear description (see Phase 9.5)
+- Define input schema matching function parameters
+- Mark required vs optional parameters correctly
+- Add retry parameters only for async operations
+
+---
+
+## Phase 7: Request Handler Implementation
+
+### Implement Handler
+- Add case for the new tool
+- Destructure parameters with correct defaults
+- Obtain authentication using existing pattern
+- Call service function with parameters in correct order
+- Return response in standard format
+- Copy error handling exactly from similar handler
+
+---
+
+## Phase 8: Compliance Review
+
+### Verify Against Project Standards
+- Parameter order matches conventions
+- Default values match conventions
+- Error handling matches existing patterns
+- Response structure matches existing patterns
+- No hardcoded values that should be configurable
+- Naming conventions followed
+
+---
+
+## Phase 9: Tool Description Review for AI Agent Clarity
+
+### Ensure Tool Description is Actionable
+
+AI agents need clear descriptions to use tools correctly. Follow this structure:
+
+```
+[Action verb] [what it does]. [Additional context].
+PREREQUISITE: [condition] (use [tool_name]).
+REQUIRED: [param1] (use [tool_name] to get [param1]) + [param2].
+[Special notes].
+```
+
+**Parameter descriptions should include tool references:**
+```
+'ID of the resource to delete (use query_resources to find resource ID)'
+'Array of venue IDs (use get_venues to get venue IDs)'
+```
+
+**Checklist:**
+- [ ] Description starts with clear action and purpose
+- [ ] Prerequisites listed with tool references
+- [ ] Required parameters explain how to obtain IDs
+- [ ] Destructive operations include warnings
+- [ ] Batch vs single operation scope is clear
+
+---
+
+## Phase 10: Summary
+
+### Report
+- Files modified and functions added
+- Pattern used as basis
+- Operation type and characteristics
+- Any deviations from standard patterns (with justification)
+
+### Testing Guidance
+- How to manually test the new tool
+- Expected input and output
+- Edge cases to verify
+- Suggest: `/ci-testcase` to generate automated tests
+
+---
+
+## Key Principles
+
+1. **Consistency First**: Copy existing patterns exactly rather than inventing new approaches
+2. **No Assumptions**: Stop and ask when unclear
+3. **No Modifications**: Do not modify retry defaults, polling intervals, or error handling without approval
+4. **Pattern Matching**: Find the most similar existing tool and follow its structure
+5. **Question Everything**: If something seems inconsistent, investigate and ask

--- a/.claude/commands/ci-run.md
+++ b/.claude/commands/ci-run.md
@@ -1,0 +1,92 @@
+# Run Test Cases
+
+Execute test cases and evaluate results with the dual-judge system.
+
+```
+{{input}}
+
+## PURPOSE
+
+Run YAML test cases by executing commands and evaluating results against patterns and criteria.
+
+---
+
+## AGENT WORKFLOW
+
+### Step 1: Load Test Cases
+
+Input can be:
+- A test ID (e.g., `TC-INT-001`) — run that specific test
+- A suite name (e.g., `integration`) — run all tests in that suite
+- Empty — run all tests
+
+Read YAML test case files from `cicd/tests/testcases/`.
+
+### Step 2: Resolve Dependencies
+
+Sort tests by:
+1. Dependencies (tests that depend on others run after)
+2. Priority (lower number = runs first)
+
+If running a specific test that has dependencies, auto-include them.
+
+### Step 3: Execute Each Test
+
+For each test case, for each step:
+
+1. **Substitute variables** — replace `{{varName}}` with captured values from previous steps
+2. **Execute the command** specified in `command`
+3. **Capture the output** (stdout and stderr)
+4. **Check expectPatterns** — each regex must match somewhere in the output
+5. **Check rejectPatterns** — none of these regexes should match
+6. **Capture variables** — if `capture` is defined, extract values from JSON output
+7. **Record result**: PASS or FAIL with evidence
+
+If a step fails, continue with remaining steps but note the failure.
+
+### Step 4: Judge Results
+
+For each test case, determine overall verdict:
+- **PASS** — all steps passed, all patterns matched, no errors detected
+- **FAIL** — any step failed, with details on which and why
+
+If a test has `criteria` and `goal` fields, evaluate whether the output semantically satisfies them.
+
+### Step 5: Report
+
+Output a summary table:
+
+```
+Test Results
+============
+TC-INT-001  Query resources            PASS  (1.2s)
+TC-INT-002  Create and verify          FAIL  (step 2: expected pattern "active" not found)
+TC-E2E-001  Full lifecycle             PASS  (5.8s)
+
+Summary: 2/3 passed
+Duration: 8.2s
+```
+
+If any test failed, show:
+- Which step failed
+- Expected vs actual output (truncated)
+- Suggested fix or investigation
+
+### Alternative: Use the CLI
+
+Instead of agent-based execution, use the built-in CLI:
+
+```bash
+cd cicd/tests
+npm test                        # All tests with LLM judge
+npm test -- --no-llm            # Without LLM judge
+npm test -- --suite integration # Specific suite
+npm test -- --id TC-INT-001     # Specific test
+npm test -- --dry-run           # Preview only
+```
+
+---
+
+## OUTPUT
+
+Test results summary with pass/fail status for each test case.

--- a/.claude/commands/ci-testcase.md
+++ b/.claude/commands/ci-testcase.md
@@ -1,0 +1,103 @@
+# Create Test Case
+
+Generate a YAML test case file from requirements or acceptance criteria.
+
+```
+{{input}}
+
+## PURPOSE
+
+Read requirements (story, ticket, or description) and generate YAML test case(s) that verify the acceptance criteria.
+
+---
+
+## AGENT WORKFLOW
+
+### Step 1: Understand Requirements
+
+Input can be:
+- A story/requirement file path — read and analyze it
+- A description of what to test — use it directly
+- A ticket ID — look for related docs or ask the user
+
+Identify:
+- What functionality to test
+- What commands or tools to call
+- What output to expect
+- What would indicate failure
+
+### Step 2: Review Existing Tests
+
+Read existing test cases in `cicd/tests/testcases/` to:
+- Find the next available ID number per suite
+- Follow existing naming and pattern conventions
+- Avoid duplicating existing coverage
+
+### Step 3: Generate Test Case YAML
+
+Create test case file(s) in `cicd/tests/testcases/<suite>/` using this format:
+
+```yaml
+id: TC-[SUITE]-[NUMBER]
+name: Descriptive test name
+suite: build|integration|e2e
+goal: One-line test objective for LLM judge
+priority: 1-10 (lower = runs first)
+timeout: 30000
+dependencies: []
+
+steps:
+  - name: Step description
+    command: <shell command or mcp-client.ts call>
+    timeout: 5000              # Optional
+    expectPatterns:
+      - "regex pattern"
+    rejectPatterns:
+      - "error"
+    capture:                   # Optional: extract values for later steps
+      varName: "json.path"
+
+criteria: |
+  Human-readable criteria for LLM judge evaluation.
+```
+
+**Suite guidelines:**
+- `build` — compilation, dependency checks, environment validation
+- `integration` — single tool/API calls, verify output format and correctness
+- `e2e` — multi-step workflows, verify end-to-end state
+
+**ID format:** `TC-BUILD-XXX`, `TC-INT-XXX`, `TC-E2E-XXX`
+
+**For MCP tool testing:**
+```yaml
+command: npx tsx cicd/tests/src/mcp-client.ts <tool_name> '{"arg":"value"}'
+```
+
+**For shell command testing:**
+```yaml
+command: curl -s http://localhost:3000/api/endpoint
+```
+
+**For multi-step with variable capture:**
+```yaml
+steps:
+  - name: Create resource
+    command: <command that returns JSON>
+    capture:
+      resourceId: "id"
+  - name: Use captured value
+    command: <command using {{resourceId}}>
+```
+
+### Step 4: Report
+
+Show the user:
+- Test case files created
+- What each test validates
+- Suggest: `/ci-run` to execute tests
+
+---
+
+## OUTPUT
+
+Paths to created test case files.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,142 @@
+# CLAUDE.md
+
+Guidance for Claude Code when working on the test-framework-template.
+
+## Project Overview
+
+Reusable, YAML-driven CI test framework with dual-judge verification (Simple + LLM). Installs into any project via `make install`. Part of the ai-qa-workflow ecosystem (Phase 5: Automate).
+
+## Core Commands
+
+```bash
+cd cicd/tests
+npm run build           # TypeScript compile
+npm test                # Run all tests with LLM judge
+npm test -- --no-llm    # Run without LLM (faster)
+npm test -- --suite build  # Run specific suite
+npm test -- --id TC-001    # Run specific test
+npm test -- --dry-run      # Preview without executing
+npm run list            # List available tests
+```
+
+Install to a project:
+```bash
+make install TARGET=/path/to/project NAME=project-name
+```
+
+## Project Structure
+
+```
+cicd/tests/
+├── src/
+│   ├── cli.ts            # CLI entry point (Commander)
+│   ├── config.ts         # Project configuration — customize per project
+│   ├── types.ts          # Core interfaces (TestCase, TestStep, etc.)
+│   ├── loader.ts         # YAML parser with dependency resolution
+│   ├── executor.ts       # Test execution with variable capture
+│   ├── mcp-client.ts     # MCP tool client for integration testing (optional)
+│   ├── log-collector.ts  # Docker log capture with test markers
+│   ├── judge/
+│   │   ├── simple-judge.ts  # Deterministic: exit codes, patterns, error detection
+│   │   └── llm-judge.ts     # Semantic: Ollama-based analysis with structured prompts
+│   └── reporter/
+│       ├── console.ts    # Colored terminal output
+│       └── json.ts       # Structured JSON for CI/CD
+├── testcases/
+│   ├── build/            # TC-BUILD-*.yml
+│   ├── integration/      # TC-INTEGRATION-*.yml (or TC-INT-*.yml)
+│   └── e2e/              # TC-E2E-*.yml
+└── package.json
+```
+
+## Test Case YAML Format
+
+```yaml
+id: TC-SUITE-NNN
+name: Human-readable test name
+suite: build|integration|e2e
+goal: One-line objective for LLM judge context
+priority: 1                    # Lower = runs first
+timeout: 30000                 # Milliseconds
+dependencies: [TC-SUITE-001]   # Tests that must pass first
+
+steps:
+  - name: Step description
+    command: shell command to execute
+    timeout: 5000              # Optional, overrides test timeout
+    expectPatterns:            # All must match (regex)
+      - "pattern"
+    rejectPatterns:            # None should match (regex)
+      - "error"
+    capture:                   # Extract values from JSON output
+      varName: "json.path"
+
+criteria: |
+  Human-readable criteria for LLM judge evaluation.
+```
+
+## Variable Capture
+
+Steps can extract values from JSON output and inject them into later steps:
+
+```yaml
+steps:
+  - name: Create resource
+    command: curl -s -X POST http://localhost:3000/api/resources
+    capture:
+      resourceId: "id"
+  - name: Verify resource
+    command: curl -s http://localhost:3000/api/resources/{{resourceId}}
+```
+
+**Path syntax:**
+- `id` — direct field
+- `data.name` — nested field
+- `data[name=foo].id` — array find by field match
+- `$[type=user].email` — root array find
+
+MCP double-encoded responses (`content[0].text` wrapping) are automatically unwrapped.
+
+## MCP Client (Optional)
+
+For MCP server projects, `mcp-client.ts` spawns the server and calls tools:
+
+```bash
+npx tsx cicd/tests/src/mcp-client.ts <tool_name> '<json_args>'
+```
+
+Configure the server command:
+- Environment variable: `MCP_SERVER_COMMAND="node dist/mcpServer.js"`
+- Default in config.ts: `mcp.serverCommand`
+
+Requires `@modelcontextprotocol/sdk` (optional peer dependency — install in your project if needed).
+
+## Dual-Judge System
+
+Both judges must pass for a test to pass:
+
+- **Simple Judge**: Exit codes = 0, expectPatterns found, rejectPatterns absent, no ERROR_PATTERNS in logs
+- **LLM Judge**: Semantic analysis of output against `criteria` and `goal` fields using Ollama
+
+Use `--no-llm` to skip LLM judging when Ollama is unavailable.
+
+## Configuration
+
+Edit `config.ts` per project:
+- `projectName` — used in LLM prompts
+- `llm.defaultUrl` / `llm.defaultModel` — Ollama endpoint
+- `ERROR_PATTERNS` / `ERROR_EXCLUSIONS` — project-specific error detection
+- `mcp.serverCommand` — MCP server startup command
+
+## Development Guidelines
+
+- Keep everything configurable via `config.ts` — never hardcode project-specific values
+- Template files get installed via Makefile — update install target for new files
+- Follow existing TypeScript patterns (strict types, async/await)
+- Test suites are configurable via `SUITES` array in config.ts
+
+## CI Flow Commands
+
+- `/ci-testcase` — generate YAML test cases from requirements
+- `/ci-run` — execute tests with guided output
+- `/add-tool` — add new MCP tools following standard patterns

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,15 @@ install: check
 	@# Copy GitHub workflows
 	@cp "$(TEMPLATE_DIR)/.github/workflows/"*.yml "$(TARGET)/.github/workflows/" 2>/dev/null || true
 
+	@# Copy CLAUDE.md if it exists
+	@if [ -f "$(TEMPLATE_DIR)/CLAUDE.md" ]; then cp "$(TEMPLATE_DIR)/CLAUDE.md" "$(TARGET)/CLAUDE.md"; fi
+
+	@# Copy Claude commands if they exist
+	@if [ -d "$(TEMPLATE_DIR)/.claude/commands" ]; then \
+		mkdir -p "$(TARGET)/.claude/commands"; \
+		cp "$(TEMPLATE_DIR)/.claude/commands/"*.md "$(TARGET)/.claude/commands/" 2>/dev/null || true; \
+	fi
+
 	@# Create .gitignore for results
 	@echo "*" > "$(TARGET)/cicd/results/.gitignore"
 	@echo "!.gitignore" >> "$(TARGET)/cicd/results/.gitignore"

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ The framework is built around three core principles:
 - **Variable Capture**: Extract values from step output and pass to later steps via `{{variable}}`
 - **Dependency Resolution**: Tests can depend on other tests passing first
 - **Log Collection with Markers**: Precise extraction of logs per test from Docker streams
+- **MCP Client**: Test MCP server tools with configurable server command
+- **Claude Commands**: AI-assisted test authoring via `/ci-testcase`, `/ci-run`, `/add-tool`
 - **Installable Template**: Add to any project via `make install`
 - **Flexible Output**: Console (colored) and JSON formats for CI consumption
 
@@ -214,6 +216,44 @@ npm run list                # List available tests
 npm test -- --judge-url http://host:11434 --judge-model gemma3:12b
 ```
 
+## MCP Testing
+
+For MCP server projects, `mcp-client.ts` spawns your server and calls tools:
+
+```bash
+# Configure your server command
+export MCP_SERVER_COMMAND="node dist/mcpServer.js"
+
+# Test a tool directly
+npx tsx cicd/tests/src/mcp-client.ts get_venues '{}'
+
+# Use in YAML test cases
+```
+
+```yaml
+steps:
+  - name: Query venues
+    command: npx tsx cicd/tests/src/mcp-client.ts get_venues '{}'
+    expectPatterns:
+      - "totalCount"
+    rejectPatterns:
+      - "isError"
+```
+
+Requires `@modelcontextprotocol/sdk` (install in your project: `npm install @modelcontextprotocol/sdk`).
+
+## Claude Commands
+
+AI-assisted workflows via Claude Code slash commands:
+
+| Command | Purpose |
+|---------|---------|
+| `/ci-testcase` | Generate YAML test cases from requirements |
+| `/ci-run` | Execute tests with guided output |
+| `/add-tool` | Add new MCP tools following standard patterns |
+
+These are installed to `.claude/commands/` by `make install`.
+
 ## Writing Test Cases
 
 Create YAML files in `cicd/tests/testcases/<suite>/`:
@@ -287,6 +327,11 @@ MCP tool responses (double-encoded JSON in `content[0].text`) are automatically 
 
 ```
 your-project/
+├── CLAUDE.md                    # AI agent guidance
+├── .claude/commands/
+│   ├── ci-testcase.md           # /ci-testcase — generate test cases
+│   ├── ci-run.md                # /ci-run — execute tests
+│   └── add-tool.md              # /add-tool — add MCP tools
 ├── cicd/
 │   ├── tests/
 │   │   ├── src/
@@ -295,6 +340,7 @@ your-project/
 │   │   │   ├── types.ts
 │   │   │   ├── loader.ts
 │   │   │   ├── executor.ts
+│   │   │   ├── mcp-client.ts    # MCP tool client (optional)
 │   │   │   ├── log-collector.ts
 │   │   │   ├── judge/
 │   │   │   └── reporter/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A reusable, YAML-driven test framework with dual-judge verification (Simple + LL
 
 ## Project Goal
 
-This test framework design template was extracted from the [ollama37](https://github.com/dogkeeper886/ollama37) project to provide a **reusable testing foundation** that can be adopted by any project.
+This test framework design template was extracted from production MCP server projects to provide a **reusable testing foundation** that can be adopted by any project.
 
 ### Why This Framework?
 

--- a/cicd/tests/package.json
+++ b/cicd/tests/package.json
@@ -26,6 +26,14 @@
     "tsx": "^4.16.0",
     "typescript": "^5.5.0"
   },
+  "peerDependencies": {
+    "@modelcontextprotocol/sdk": ">=1.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@modelcontextprotocol/sdk": {
+      "optional": true
+    }
+  },
   "engines": {
     "node": ">=18.0.0"
   }

--- a/cicd/tests/src/config.ts
+++ b/cicd/tests/src/config.ts
@@ -39,6 +39,11 @@ export const CONFIG = {
     cleanupAge: 24 * 60 * 60 * 1000, // 24 hours
     maxBuffer: 50 * 1024 * 1024, // 50MB
   },
+
+  // MCP client settings (for projects using mcp-client.ts)
+  mcp: {
+    serverCommand: 'node dist/mcpServer.js', // Override via MCP_SERVER_COMMAND env var
+  },
 };
 
 /**

--- a/cicd/tests/src/mcp-client.ts
+++ b/cicd/tests/src/mcp-client.ts
@@ -1,0 +1,37 @@
+#!/usr/bin/env npx tsx
+/**
+ * Lightweight MCP client CLI for integration testing.
+ * Spawns the MCP server, calls a tool, prints the result as JSON.
+ *
+ * Usage: npx tsx cicd/tests/src/mcp-client.ts <tool_name> '<json_args>'
+ *
+ * Configure the server command via MCP_SERVER_COMMAND env var.
+ * Default: node dist/mcpServer.js
+ */
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+const [toolName, argsJson] = process.argv.slice(2);
+if (!toolName) {
+  console.error('Usage: mcp-client.ts <tool_name> [json_args]');
+  process.exit(1);
+}
+
+const args = argsJson ? JSON.parse(argsJson) : {};
+
+const serverCommand = process.env.MCP_SERVER_COMMAND || 'node dist/mcpServer.js';
+const [cmd, ...cmdArgs] = serverCommand.split(' ');
+
+const transport = new StdioClientTransport({
+  command: cmd,
+  args: cmdArgs,
+  env: { ...process.env } as Record<string, string>,
+});
+
+const client = new Client({ name: 'test-client', version: '1.0.0' });
+await client.connect(transport);
+
+const result = await client.callTool({ name: toolName, arguments: args });
+console.log(JSON.stringify(result, null, 2));
+
+await client.close();

--- a/cicd/tests/tsconfig.json
+++ b/cicd/tests/tsconfig.json
@@ -16,5 +16,5 @@
     "sourceMap": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/mcp-client.ts"]
 }


### PR DESCRIPTION
## Summary
- Add three generalized slash commands for AI-assisted test authoring and MCP tool development
- Update README with MCP Testing section, Claude Commands table, and expanded directory structure

## New commands
- **`/ci-testcase`**: Generate YAML test cases from requirements — supports both shell commands and MCP tool calls, includes variable capture syntax
- **`/ci-run`**: Execute tests with guided dual-judge output — resolves dependencies, evaluates patterns, reports results
- **`/add-tool`**: Step-by-step MCP tool implementation guide with 7 operation patterns (read-only, async polling, conditional async, retrieve-then-update, type-based conditional/early-return, optional payload) and AI agent description review

## Test plan
- [ ] Commands render correctly via `/ci-testcase`, `/ci-run`, `/add-tool` in Claude Code
- [ ] `make install TARGET=/tmp/test-project` copies commands to `.claude/commands/`
- [ ] README renders correctly with new sections

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)