### PR TITLE
Add agent-driven installation flow

### DIFF
--- a/.claude/commands/install.md
+++ b/.claude/commands/install.md
@@ -1,0 +1,118 @@
+# Install Test Framework
+
+Install the dual-judge test framework into the current project.
+
+```
+{{input}}
+
+## PURPOSE
+
+Install the test framework from the template source into the user's current working directory, adapting configuration to the project's needs.
+
+---
+
+## AGENT WORKFLOW
+
+### Step 1: Locate Template Source
+
+Input is the path to the test-framework-template repo:
+- If provided: use it directly
+- If empty: check common locations (`~/src/test-framework-template`, `../test-framework-template`)
+- If not found: ask the user for the path
+
+Read the template's `CLAUDE.md` to understand available components and the installation flow.
+
+### Step 2: Detect Project Context
+
+Examine the current working directory:
+
+1. **Read `package.json`** — extract project name, check for `@modelcontextprotocol/sdk`
+2. **Check for `docker-compose.yml`** — Docker project?
+3. **Check for existing `cicd/tests/`** — fresh install or update?
+4. **Check `.claude/commands/`** — what's already installed?
+
+### Step 3: Ask Configuration Questions
+
+Prompt the user with detected defaults:
+
+- **Project name** — from package.json or ask
+- **Ollama URL** — default: `http://localhost:11434`
+- **Ollama model** — default: `llama3:8b`
+- **Include MCP client?** — auto-yes if MCP SDK detected
+- **Include Docker log collector?** — auto-yes if docker-compose found
+- **Install Claude commands?** — recommend yes
+- **Install example test cases?** — yes for fresh install, ask for updates
+
+### Step 4: Install
+
+1. **Create directories:**
+   - `cicd/tests/src/judge/`
+   - `cicd/tests/src/reporter/`
+   - `cicd/tests/testcases/{build,integration,e2e}/`
+   - `cicd/scripts/`
+   - `cicd/results/`
+
+2. **Copy files** from template source to current project:
+   - Core: `cli.ts`, `config.ts`, `types.ts`, `loader.ts`, `executor.ts`
+   - Judges: `judge/simple-judge.ts`, `judge/llm-judge.ts`, `judge/index.ts`
+   - Reporters: `reporter/console.ts`, `reporter/json.ts`, `reporter/index.ts`
+   - Supporting: `package.json`, `tsconfig.json`
+   - Conditional: `log-collector.ts` (Docker), `mcp-client.ts` (MCP)
+   - Commands: `ci-testcase.md`, `ci-run.md`, `add-tool.md` (to `.claude/commands/`)
+   - Examples: test case YAML files (if selected)
+   - Scripts: `format-results.sh`
+
+3. **Adapt config.ts** — replace placeholder values with user's answers:
+   - `projectName: 'my-project'` → actual project name
+   - `sessionPrefix: 'test-session'` → `'{name}-session'`
+   - `llm.defaultUrl` → user's Ollama URL
+   - `llm.defaultModel` → user's model
+
+4. **Create `.gitignore`** in `cicd/results/`:
+   ```
+   *
+   !.gitignore
+   ```
+
+5. **Run `npm install`** in `cicd/tests/`
+
+### Step 5: Verify
+
+1. Run `cd cicd/tests && npm run build` — must compile
+2. Run `npm run list` — must load test cases
+3. If either fails, diagnose and fix
+
+### Step 6: Report
+
+Show the user:
+- What was installed (components list)
+- Configuration values applied
+- Next steps:
+  - Write test cases: `cicd/tests/testcases/<suite>/*.yml`
+  - Customize error patterns: `cicd/tests/src/config.ts`
+  - Run tests: `cd cicd/tests && npm test -- --no-llm`
+  - Generate test cases: `/ci-testcase`
+
+---
+
+## FOR UPDATES
+
+If `cicd/tests/` already exists:
+
+1. **Preserve user files** — do NOT overwrite:
+   - `config.ts` (user's configuration)
+   - `testcases/**/*.yml` (user's test cases)
+   - Any files the user has customized
+
+2. **Update framework files** — compare and update:
+   - `executor.ts`, `loader.ts`, `types.ts`, `cli.ts`
+   - Judge and reporter files
+   - `package.json` (merge dependencies, don't overwrite scripts)
+
+3. **Show diff** before applying updates — let user approve changes
+
+---
+
+## OUTPUT
+
+Summary of installed/updated components with next steps.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,113 @@ Guidance for Claude Code when working on the test-framework-template.
 
 ## Project Overview
 
-Reusable, YAML-driven CI test framework with dual-judge verification (Simple + LLM). Installs into any project via `make install`. Part of the ai-qa-workflow ecosystem (Phase 5: Automate).
+Reusable, YAML-driven CI test framework with dual-judge verification (Simple + LLM). Part of the ai-qa-workflow ecosystem (Phase 5: Automate).
+
+## Installation
+
+Installation is agent-driven. When an AI agent reads this file, it should guide the user through installing the framework into their project.
+
+### Agent Installation Flow
+
+#### Phase 1: Orient
+
+Read this CLAUDE.md to understand available components. Each component is conditional:
+
+| Component | Files | When to include |
+|-----------|-------|----------------|
+| **Core framework** (always) | cli.ts, config.ts, types.ts, loader.ts, executor.ts | Always |
+| **Judges** (always) | judge/simple-judge.ts, judge/llm-judge.ts, judge/index.ts | Always |
+| **Reporters** (always) | reporter/console.ts, reporter/json.ts, reporter/index.ts | Always |
+| **Docker log collector** | log-collector.ts | If project uses Docker (docker-compose.yml exists) |
+| **MCP client** | mcp-client.ts | If project is an MCP server (`@modelcontextprotocol/sdk` in package.json) |
+| **Claude commands** | .claude/commands/{ci-testcase,ci-run,add-tool}.md | Recommended for all projects |
+| **GitHub workflows** | .github/workflows/{test-pipeline,test-suite}.yml | Optional |
+| **Example test cases** | testcases/{build,integration,e2e}/*.yml | Recommended for fresh install, skip for updates |
+| **Supporting files** | package.json, tsconfig.json, scripts/format-results.sh | Always |
+
+#### Phase 2: Detect Context
+
+Examine the user's current working directory:
+
+1. **Read package.json** (if it exists) → extract project name, check for `@modelcontextprotocol/sdk` in dependencies
+2. **Check for docker-compose.yml** → Docker project? Include log-collector.ts
+3. **Check for existing `cicd/tests/`** → update (preserve user's config.ts and test cases) vs fresh install
+4. **Check `.claude/commands/`** → what commands are already installed
+5. **If no project context detected**, ask the user what they're working on
+
+#### Phase 3: Ask the User
+
+Prompt for configuration (show defaults, let user override):
+
+1. **Project name** — default from package.json `name` field, or ask
+2. **Ollama URL** — default: `http://localhost:11434`
+3. **Ollama model** — default: `llama3:8b`
+4. **Include MCP client?** — auto-yes if MCP SDK detected, otherwise ask
+5. **Include Docker log collector?** — auto-yes if docker-compose detected, otherwise ask
+6. **Install Claude commands?** — recommend yes
+7. **Install example test cases?** — recommend yes for fresh install, skip for updates
+
+#### Phase 4: Install
+
+1. **Create directory structure:**
+   ```
+   cicd/tests/src/judge/
+   cicd/tests/src/reporter/
+   cicd/tests/testcases/{build,integration,e2e}/
+   cicd/scripts/
+   cicd/results/
+   ```
+
+2. **Copy selected files** from the template source directory into the target project
+
+3. **Adapt config.ts** with user's answers — replace placeholder values:
+   - `projectName: 'my-project'` → user's project name
+   - `sessionPrefix: 'test-session'` → `'{projectName}-session'`
+   - `llm.defaultUrl` → user's Ollama URL
+   - `llm.defaultModel` → user's model
+   - If MCP: set `mcp.serverCommand` to match their server
+
+4. **Adapt package.json** — if MCP client included, add `@modelcontextprotocol/sdk` to peerDependencies
+
+5. **Create .gitignore** in `cicd/results/`:
+   ```
+   *
+   !.gitignore
+   ```
+
+6. **Run `npm install`** in `cicd/tests/`
+
+#### Phase 5: Verify
+
+1. Run `cd cicd/tests && npm run build` — TypeScript must compile
+2. Run `npm run list` — test loader must work (shows example test cases if installed)
+3. If either fails, diagnose and fix before reporting success
+
+#### Phase 6: Report
+
+Show the user:
+- Summary of installed components (what was included/excluded and why)
+- Configuration values applied
+- Next steps:
+  - Write test cases in `cicd/tests/testcases/`
+  - Customize error patterns in `config.ts`
+  - Run tests: `cd cicd/tests && npm test -- --no-llm`
+
+### Updates
+
+To update an existing installation, run the same flow. The agent should:
+- Compare installed files against the template source (check for divergence)
+- Preserve the user's `config.ts` customizations, test cases, and error patterns
+- Only update framework files (judges, executor, loader, etc.)
+- Show what changed before applying updates
+
+### Manual Installation (Alternative)
+
+```bash
+make install TARGET=/path/to/project NAME=project-name
+cd /path/to/project/cicd/tests && npm install
+# Then manually edit config.ts
+```
 
 ## Core Commands
 
@@ -131,7 +237,7 @@ Edit `config.ts` per project:
 ## Development Guidelines
 
 - Keep everything configurable via `config.ts` — never hardcode project-specific values
-- Template files get installed via Makefile — update install target for new files
+- Template files are installed via agent-driven flow (see Installation section) or Makefile fallback
 - Follow existing TypeScript patterns (strict types, async/await)
 - Test suites are configurable via `SUITES` array in config.ts
 

--- a/README.md
+++ b/README.md
@@ -150,18 +150,28 @@ Use `--no-llm` to skip LLM judging for faster CI feedback when Ollama is unavail
 
 ## Quick Start
 
+### Recommended: Agent-Driven Install
+
+In your project directory, tell Claude Code:
+
+> Install the test framework from /path/to/test-framework-template
+
+Or use the slash command:
+
+```
+/install /path/to/test-framework-template
+```
+
+The agent will detect your project type (MCP server, Docker, etc.), ask configuration questions, and install only what you need with values pre-configured.
+
+### Alternative: Manual Install
+
 ```bash
-# Clone or download this template, then install to your project
 cd /path/to/test-framework-template
 make install TARGET=/path/to/your/project NAME=your-project
-
-# Example:
-make install TARGET=/home/user/src/my-app NAME=my-app
-
-# Then in your project
 cd /path/to/your/project/cicd/tests
 npm install
-npm test
+# Then edit config.ts manually
 ```
 
 ## Makefile Commands


### PR DESCRIPTION
## Summary
- Replace `make install` as primary installation method with an agent-driven flow following ai-qa-workflow's pattern
- Agent detects project context (MCP server? Docker? Existing install?), asks config questions, installs selectively
- Add `/install` slash command to encapsulate the workflow

## Changes
- **CLAUDE.md**: Add 6-phase Installation section (orient, detect context, ask user, install, verify, report) with component table showing conditional inclusion
- **`.claude/commands/install.md`** (new): Slash command wrapping the installation flow, supports both fresh installs and updates
- **README.md**: Rewrite Quick Start — agent-driven first, `make install` as alternative

## How it works

User in their project directory says:
```
/install /path/to/test-framework-template
```

The agent:
1. Reads template CLAUDE.md for component list
2. Checks package.json (project name, MCP SDK), docker-compose.yml, existing cicd/tests/
3. Asks: project name, Ollama URL/model, include MCP client?, include log collector?, install commands?
4. Copies selected files, adapts config.ts with answers
5. Runs `npm install` + `npm run build` to verify
6. Reports what was installed

For updates: preserves user's config.ts, test cases, and customizations — only updates framework files.

## Test plan
- [ ] `/install` command renders correctly in Claude Code
- [ ] CLAUDE.md installation instructions are clear and complete
- [ ] `make install` still works unchanged (no Makefile changes)
- [ ] README shows agent-driven as primary, manual as alternative

Fixes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)