### PR TITLE
Add deprecation notice to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,11 @@ ifndef TARGET
 endif
 
 install: check
+	@echo "NOTE: Consider using agent-driven installation instead."
+	@echo "  In your project, tell Claude Code:"
+	@echo "    /install $(TEMPLATE_DIR)"
+	@echo "  See README.md for details."
+	@echo ""
 	@echo "Installing test framework to: $(TARGET)"
 	@echo "Project name: $(NAME)"
 	@echo ""

--- a/README.md
+++ b/README.md
@@ -174,12 +174,10 @@ npm install
 # Then edit config.ts manually
 ```
 
-## Makefile Commands
+Additional Makefile commands:
 
 ```bash
 make help                                    # Show usage
-make install TARGET=/path/to/project         # Install with default name
-make install TARGET=/path/to/project NAME=x  # Install with custom name
 make clean TARGET=/path/to/project           # Remove framework from project
 ```
 


### PR DESCRIPTION
## Summary
- Makefile `install` target now prints a note suggesting `/install` command
- README demotes Makefile commands under the "Alternative" section

## Changes
- **Makefile**: Add 4-line deprecation notice at start of `install` target (all functionality unchanged)
- **README.md**: Consolidate Makefile commands under Alternative heading, remove separate top-level section

## Test plan
- [ ] `make install TARGET=/tmp/test` still works and shows deprecation notice
- [ ] README renders correctly with demoted Makefile section

Fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)