### PR TITLE
Backport per-feature CI workflows, tag filtering, and modernize Claude Code

### DIFF
--- a/.claude/rules/test-yaml-format.md
+++ b/.claude/rules/test-yaml-format.md
@@ -1,0 +1,86 @@
+---
+paths:
+  - "cicd/tests/testcases/**/*.yml"
+  - "cicd/tests/src/types.ts"
+  - "cicd/tests/src/loader.ts"
+---
+
+# Test Case YAML Format
+
+## Schema
+
+```yaml
+id: TC-[SUITE]-[NUMBER]
+name: Human-readable test name
+suite: build|integration|e2e      # Extensible — add custom suites in config.ts
+goal: One-line objective for LLM judge context
+priority: 1                        # Lower = runs first
+timeout: 30000                     # Milliseconds
+dependencies: [TC-SUITE-001]       # Tests that must pass first
+tags: [feature-name]               # For --tag filtering (optional)
+
+steps:
+  - name: Step description
+    command: shell command to execute
+    timeout: 5000                  # Optional, overrides test timeout
+    expectPatterns:                # All must match (regex)
+      - "pattern"
+    rejectPatterns:                # None should match (regex)
+      - "error"
+    capture:                       # Extract values from JSON output
+      varName: "json.path"
+
+criteria: |
+  Human-readable criteria for LLM judge evaluation.
+```
+
+## Tags
+
+Tags enable per-feature CI workflows. Use feature names or capability areas:
+
+```yaml
+tags: [auth, api]          # Feature tags
+tags: [build, compile]     # Suite-aligned tags
+tags: [smoke]              # Test category tags
+```
+
+Filter by tag: `npm test -- --tag auth` or `npm run list -- --tag auth`
+
+## Variable Capture
+
+Steps can extract values from JSON output and inject them into later steps:
+
+```yaml
+steps:
+  - name: Create resource
+    command: curl -s -X POST http://localhost:3000/api/resources
+    capture:
+      resourceId: "id"
+  - name: Verify resource
+    command: curl -s http://localhost:3000/api/resources/{{resourceId}}
+```
+
+**Path syntax:**
+- `id` — direct field
+- `data.name` — nested field
+- `data[name=foo].id` — array find by field match
+- `$[type=user].email` — root array find
+
+Variables resolve from captured step output first, then fall back to `process.env`. This enables CI-friendly patterns like `{{TEST_API_KEY}}` without hardcoding values.
+
+MCP double-encoded responses (`content[0].text` wrapping) are automatically unwrapped.
+
+## Suite Guidelines
+
+- `build` — compilation, dependency checks, environment validation
+- `integration` — single tool/API calls, verify output format and correctness
+- `e2e` — multi-step workflows, verify end-to-end state
+
+Add custom suites by extending the `SUITES` array in `config.ts`.
+
+## ID Format
+
+- `TC-BUILD-XXX`
+- `TC-INT-XXX`
+- `TC-E2E-XXX`
+- Custom: `TC-{SUITE}-XXX` (match your suite names)

--- a/.claude/rules/workflow-patterns.md
+++ b/.claude/rules/workflow-patterns.md
@@ -1,0 +1,60 @@
+---
+paths:
+  - ".github/workflows/**/*.yml"
+---
+
+# CI Workflow Patterns
+
+## Per-Feature Workflow Pattern
+
+Split CI into composable, independently triggerable workflows:
+
+```
+.github/workflows/
+├── build.yml                # Standalone build step
+├── test-run.yml             # Reusable test runner (called by feature workflows)
+├── test-<feature>.yml       # One per feature (~25 lines, thin delegator)
+└── ci.yml                   # Full pipeline: build -> all features in parallel
+```
+
+**Adding a new feature test:**
+1. Tag test cases: `tags: [my-feature]`
+2. Copy `test-feature-example.yml` -> `test-my-feature.yml`
+3. Change the `tag` input value to `my-feature`
+4. Add the new workflow as a job in `ci.yml`
+
+### Suite-Based Alternative
+
+For projects organized by test suite rather than feature:
+
+```
+.github/workflows/
+├── build.yml
+├── test-run.yml             # Same reusable runner
+├── test-build.yml           # Uses --suite build
+├── test-integration.yml     # Uses --suite integration
+└── ci.yml                   # Orchestrates all suites
+```
+
+Both patterns use `test-run.yml` as the single reusable job.
+
+## Key Design Decisions
+
+**Dual triggers:** Each workflow supports both `workflow_dispatch` (manual, with dropdowns) and `workflow_call` (callable from pipeline). This lets you run features independently or as part of the full CI.
+
+**Judge mode dropdown:** Each workflow offers `simple` (fast, no LLM) or `dual` (simple + LLM) judge modes via input.
+
+## Environment Variables
+
+Configure LLM judge via GitHub repository variables (`Settings > Variables > Actions`):
+
+| Variable | Purpose | Example |
+|----------|---------|---------|
+| `LLM_JUDGE_URL` | Ollama endpoint | `http://localhost:11434` |
+| `LLM_JUDGE_MODEL` | Model for judging | `llama3:8b` |
+
+**Separate judge instance:** If your project tests an Ollama instance (e.g., on port 11434), run the LLM judge on a different port (e.g., 11435) to avoid GPU memory contention. Set `LLM_JUDGE_URL=http://localhost:11435` in your repo variables.
+
+## Legacy Workflows
+
+`test-pipeline.yml` and `test-suite.yml` are the original suite-based workflows. They still work but the per-feature pattern (`ci.yml` + `test-run.yml`) is recommended for projects with many test cases.

--- a/.claude/skills/add-tool/SKILL.md
+++ b/.claude/skills/add-tool/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: add-tool
+description: Add new MCP tools following standard patterns and guidelines
+user-invocable: true
+---
+
 # Add New MCP Tool
 
 Add a new MCP tool to this server following established patterns and guidelines.

--- a/.claude/skills/ci-run/SKILL.md
+++ b/.claude/skills/ci-run/SKILL.md
@@ -1,9 +1,15 @@
+---
+name: ci-run
+description: Execute test cases with dual-judge evaluation
+user-invocable: true
+---
+
 # Run Test Cases
 
 Execute test cases and evaluate results with the dual-judge system.
 
 ```
-{{input}}
+$ARGUMENTS
 
 ## PURPOSE
 
@@ -18,6 +24,7 @@ Run YAML test cases by executing commands and evaluating results against pattern
 Input can be:
 - A test ID (e.g., `TC-INT-001`) — run that specific test
 - A suite name (e.g., `integration`) — run all tests in that suite
+- A tag name (e.g., `auth`) — run all tests with that tag
 - Empty — run all tests
 
 Read YAML test case files from `cicd/tests/testcases/`.
@@ -34,7 +41,7 @@ If running a specific test that has dependencies, auto-include them.
 
 For each test case, for each step:
 
-1. **Substitute variables** — replace `{{varName}}` with captured values from previous steps
+1. **Substitute variables** — replace `{{varName}}` with captured values from previous steps (falls back to `process.env`)
 2. **Execute the command** specified in `command`
 3. **Capture the output** (stdout and stderr)
 4. **Check expectPatterns** — each regex must match somewhere in the output
@@ -82,8 +89,13 @@ npm test                        # All tests with LLM judge
 npm test -- --no-llm            # Without LLM judge
 npm test -- --suite integration # Specific suite
 npm test -- --id TC-INT-001     # Specific test
+npm test -- --tag auth          # Tests tagged 'auth'
 npm test -- --dry-run           # Preview only
 ```
+
+**Environment variables for CI:**
+- `LLM_JUDGE_URL` — Ollama endpoint (default: `http://localhost:11434`)
+- `LLM_JUDGE_MODEL` — Model for judging (default: `llama3:8b`)
 
 ---
 

--- a/.claude/skills/ci-testcase/SKILL.md
+++ b/.claude/skills/ci-testcase/SKILL.md
@@ -1,9 +1,15 @@
+---
+name: ci-testcase
+description: Generate YAML test cases from requirements or acceptance criteria
+user-invocable: true
+---
+
 # Create Test Case
 
 Generate a YAML test case file from requirements or acceptance criteria.
 
 ```
-{{input}}
+$ARGUMENTS
 
 ## PURPOSE
 
@@ -45,6 +51,7 @@ goal: One-line test objective for LLM judge
 priority: 1-10 (lower = runs first)
 timeout: 30000
 dependencies: []
+tags: [feature-name]
 
 steps:
   - name: Step description
@@ -68,6 +75,8 @@ criteria: |
 
 **ID format:** `TC-BUILD-XXX`, `TC-INT-XXX`, `TC-E2E-XXX`
 
+**Tags:** Use feature names or capability areas (e.g., `auth`, `api`, `build`). Tags enable per-feature CI workflows via `--tag`.
+
 **For MCP tool testing:**
 ```yaml
 command: npx tsx cicd/tests/src/mcp-client.ts <tool_name> '{"arg":"value"}'
@@ -88,6 +97,8 @@ steps:
   - name: Use captured value
     command: <command using {{resourceId}}>
 ```
+
+Variables resolve from captured step output first, then fall back to `process.env`.
 
 ### Step 4: Report
 

--- a/.claude/skills/install/SKILL.md
+++ b/.claude/skills/install/SKILL.md
@@ -1,9 +1,15 @@
+---
+name: install
+description: Install test framework into a project with agent-driven configuration
+user-invocable: true
+---
+
 # Install Test Framework
 
 Install the dual-judge test framework into the current project.
 
 ```
-{{input}}
+$ARGUMENTS
 
 ## PURPOSE
 
@@ -29,7 +35,7 @@ Examine the current working directory:
 1. **Read `package.json`** — extract project name, check for `@modelcontextprotocol/sdk`
 2. **Check for `docker-compose.yml`** — Docker project?
 3. **Check for existing `cicd/tests/`** — fresh install or update?
-4. **Check `.claude/commands/`** — what's already installed?
+4. **Check `.claude/skills/`** — what skills are already installed?
 
 ### Step 3: Ask Configuration Questions
 
@@ -40,7 +46,7 @@ Prompt the user with detected defaults:
 - **Ollama model** — default: `llama3:8b`
 - **Include MCP client?** — auto-yes if MCP SDK detected
 - **Include Docker log collector?** — auto-yes if docker-compose found
-- **Install Claude commands?** — recommend yes
+- **Install Claude skills?** — recommend yes
 - **Install example test cases?** — yes for fresh install, ask for updates
 
 ### Step 4: Install
@@ -58,15 +64,16 @@ Prompt the user with detected defaults:
    - Reporters: `reporter/console.ts`, `reporter/json.ts`, `reporter/index.ts`
    - Supporting: `package.json`, `tsconfig.json`
    - Conditional: `log-collector.ts` (Docker), `mcp-client.ts` (MCP)
-   - Commands: `ci-testcase.md`, `ci-run.md`, `add-tool.md` (to `.claude/commands/`)
+   - Skills: `ci-testcase`, `ci-run`, `add-tool` (to `.claude/skills/`)
+   - Rules: `test-yaml-format.md`, `workflow-patterns.md` (to `.claude/rules/`)
    - Examples: test case YAML files (if selected)
    - Scripts: `format-results.sh`
 
 3. **Adapt config.ts** — replace placeholder values with user's answers:
-   - `projectName: 'my-project'` → actual project name
-   - `sessionPrefix: 'test-session'` → `'{name}-session'`
-   - `llm.defaultUrl` → user's Ollama URL
-   - `llm.defaultModel` → user's model
+   - `projectName: 'my-project'` -> actual project name
+   - `sessionPrefix: 'test-session'` -> `'{name}-session'`
+   - `llm.defaultUrl` -> user's Ollama URL
+   - `llm.defaultModel` -> user's model
 
 4. **Create `.gitignore`** in `cicd/results/`:
    ```

--- a/.claude/skills/review-docs-privacy/SKILL.md
+++ b/.claude/skills/review-docs-privacy/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: review-docs-privacy
+description: Review codebase for documentation quality and information security
+user-invocable: true
+---
+
 # Review Guidelines
 
 Review the codebase for documentation quality and information security.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: Build
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: cd cicd/tests && npm ci
+
+      - name: Build
+        run: cd cicd/tests && npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI Pipeline
+
+on:
+  workflow_dispatch:
+    inputs:
+      judge_mode:
+        description: "Judge mode"
+        required: false
+        default: "simple"
+        type: choice
+        options:
+          - "simple"
+          - "dual"
+      judge_model:
+        description: "LLM model for judging (if dual mode)"
+        required: false
+        default: "llama3:8b"
+        type: string
+
+jobs:
+  build:
+    name: Build
+    uses: ./.github/workflows/build.yml
+
+  # Add per-feature test jobs here. Each runs in parallel after build.
+  # Example:
+  #
+  # test-auth:
+  #   name: "Test: Auth"
+  #   needs: build
+  #   uses: ./.github/workflows/test-run.yml
+  #   with:
+  #     tag: auth
+  #     judge_mode: ${{ inputs.judge_mode }}
+  #     judge_model: ${{ inputs.judge_model }}
+
+  # Default: run all tests (no tag filter)
+  test-all:
+    name: "Test: All"
+    needs: build
+    uses: ./.github/workflows/test-run.yml
+    with:
+      judge_mode: ${{ inputs.judge_mode }}
+      judge_model: ${{ inputs.judge_model }}

--- a/.github/workflows/test-feature-example.yml
+++ b/.github/workflows/test-feature-example.yml
@@ -1,0 +1,35 @@
+# Example per-feature test workflow.
+#
+# To add a new feature test:
+# 1. Copy this file to test-<feature>.yml
+# 2. Change the name and tag value below
+# 3. Add it as a job in ci.yml
+#
+# Each feature workflow is ~25 lines — a thin delegator to test-run.yml.
+
+name: "Test: Example Feature"
+
+on:
+  workflow_dispatch:
+    inputs:
+      judge_mode:
+        description: "Judge mode"
+        required: false
+        default: "simple"
+        type: choice
+        options:
+          - "simple"
+          - "dual"
+  workflow_call:
+    inputs:
+      judge_mode:
+        required: false
+        default: "simple"
+        type: string
+
+jobs:
+  test:
+    uses: ./.github/workflows/test-run.yml
+    with:
+      tag: "example"                    # <-- Change this to your feature tag
+      judge_mode: ${{ inputs.judge_mode }}

--- a/.github/workflows/test-pipeline.yml
+++ b/.github/workflows/test-pipeline.yml
@@ -1,3 +1,4 @@
+# Legacy — see ci.yml + test-run.yml for the per-feature workflow pattern
 name: Full Test Pipeline
 
 on:

--- a/.github/workflows/test-run.yml
+++ b/.github/workflows/test-run.yml
@@ -1,0 +1,102 @@
+name: Test Run
+
+# Reusable test runner — called by per-feature or per-suite workflows.
+# Supports both --tag and --suite filtering.
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: "Run tests with this tag (e.g., auth, build)"
+        required: false
+        type: string
+      suite:
+        description: "Run tests in this suite (e.g., build, integration, e2e)"
+        required: false
+        type: string
+      judge_mode:
+        description: "Judge mode (simple = no LLM, dual = simple + LLM)"
+        required: false
+        default: "simple"
+        type: string
+      judge_model:
+        description: "LLM model for judging"
+        required: false
+        default: "llama3:8b"
+        type: string
+    outputs:
+      result:
+        description: "Test result"
+        value: ${{ jobs.test.outputs.result }}
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.run-tests.outcome }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: cd cicd/tests && npm ci
+
+      - name: Build test runner
+        run: cd cicd/tests && npm run build
+
+      - name: Run tests
+        id: run-tests
+        env:
+          LLM_JUDGE_URL: ${{ vars.LLM_JUDGE_URL || 'http://localhost:11434' }}
+          LLM_JUDGE_MODEL: ${{ vars.LLM_JUDGE_MODEL || inputs.judge_model }}
+        run: |
+          cd cicd/tests
+
+          # Build filter flags
+          FILTER_FLAGS=""
+          if [ -n "${{ inputs.tag }}" ]; then
+            FILTER_FLAGS="--tag ${{ inputs.tag }}"
+          elif [ -n "${{ inputs.suite }}" ]; then
+            FILTER_FLAGS="--suite ${{ inputs.suite }}"
+          fi
+
+          # Build judge flags
+          JUDGE_FLAGS=""
+          if [ "${{ inputs.judge_mode }}" = "simple" ]; then
+            JUDGE_FLAGS="--no-llm"
+          else
+            JUDGE_FLAGS="--judge-model ${{ inputs.judge_model }}"
+          fi
+
+          echo "Filter: $FILTER_FLAGS"
+          echo "Judge: $JUDGE_FLAGS"
+
+          npx tsx src/cli.ts run $FILTER_FLAGS $JUDGE_FLAGS --format json > /tmp/test-results.json || true
+
+          echo "--- Results ---"
+          cat /tmp/test-results.json
+
+      - name: Check results
+        run: |
+          FAILED=$(jq '.summary.failed' /tmp/test-results.json)
+          echo "Failed tests: $FAILED"
+          if [ "$FAILED" -gt 0 ]; then
+            echo "::error::$FAILED test(s) failed"
+            exit 1
+          fi
+
+      - name: Upload results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results-${{ inputs.tag || inputs.suite || 'all' }}
+          path: |
+            /tmp/test-results.json
+            cicd/results/

--- a/.github/workflows/test-run.yml
+++ b/.github/workflows/test-run.yml
@@ -53,11 +53,14 @@ jobs:
 
       - name: Run tests
         id: run-tests
-        env:
-          LLM_JUDGE_URL: ${{ vars.LLM_JUDGE_URL || 'http://localhost:11434' }}
-          LLM_JUDGE_MODEL: ${{ vars.LLM_JUDGE_MODEL || inputs.judge_model }}
         run: |
           cd cicd/tests
+
+          # Set LLM judge env vars from repo variables (fall back to defaults)
+          export LLM_JUDGE_URL="${{ vars.LLM_JUDGE_URL }}"
+          export LLM_JUDGE_MODEL="${{ vars.LLM_JUDGE_MODEL }}"
+          [ -z "$LLM_JUDGE_URL" ] && export LLM_JUDGE_URL="http://localhost:11434"
+          [ -z "$LLM_JUDGE_MODEL" ] && export LLM_JUDGE_MODEL="${{ inputs.judge_model }}"
 
           # Build filter flags
           FILTER_FLAGS=""

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -1,3 +1,4 @@
+# Legacy — see ci.yml + test-run.yml for the per-feature workflow pattern
 name: Test Suite
 
 on:

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ dist/
 cicd/results/*
 !cicd/results/.gitignore
 
+# Claude Code local settings
+.claude/settings.local.json
+
 # IDE
 .idea/
 .vscode/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,126 +8,28 @@ Reusable, YAML-driven CI test framework with dual-judge verification (Simple + L
 
 ## Installation
 
-Installation is agent-driven. When an AI agent reads this file, it should guide the user through installing the framework into their project.
+Agent-driven: run `/install` and follow the prompts.
 
-### Agent Installation Flow
-
-#### Phase 1: Orient
-
-Read this CLAUDE.md to understand available components. Each component is conditional:
-
-| Component | Files | When to include |
-|-----------|-------|----------------|
-| **Core framework** (always) | cli.ts, config.ts, types.ts, loader.ts, executor.ts | Always |
-| **Judges** (always) | judge/simple-judge.ts, judge/llm-judge.ts, judge/index.ts | Always |
-| **Reporters** (always) | reporter/console.ts, reporter/json.ts, reporter/index.ts | Always |
-| **Docker log collector** | log-collector.ts | If project uses Docker (docker-compose.yml exists) |
-| **MCP client** | mcp-client.ts | If project is an MCP server (`@modelcontextprotocol/sdk` in package.json) |
-| **Claude commands** | .claude/commands/{ci-testcase,ci-run,add-tool}.md | Recommended for all projects |
-| **GitHub workflows** | .github/workflows/{test-pipeline,test-suite}.yml | Optional |
-| **Example test cases** | testcases/{build,integration,e2e}/*.yml | Recommended for fresh install, skip for updates |
-| **Supporting files** | package.json, tsconfig.json, scripts/format-results.sh | Always |
-
-#### Phase 2: Detect Context
-
-Examine the user's current working directory:
-
-1. **Read package.json** (if it exists) → extract project name, check for `@modelcontextprotocol/sdk` in dependencies
-2. **Check for docker-compose.yml** → Docker project? Include log-collector.ts
-3. **Check for existing `cicd/tests/`** → update (preserve user's config.ts and test cases) vs fresh install
-4. **Check `.claude/commands/`** → what commands are already installed
-5. **If no project context detected**, ask the user what they're working on
-
-#### Phase 3: Ask the User
-
-Prompt for configuration (show defaults, let user override):
-
-1. **Project name** — default from package.json `name` field, or ask
-2. **Ollama URL** — default: `http://localhost:11434`
-3. **Ollama model** — default: `llama3:8b`
-4. **Include MCP client?** — auto-yes if MCP SDK detected, otherwise ask
-5. **Include Docker log collector?** — auto-yes if docker-compose detected, otherwise ask
-6. **Install Claude commands?** — recommend yes
-7. **Install example test cases?** — recommend yes for fresh install, skip for updates
-
-#### Phase 4: Install
-
-1. **Create directory structure:**
-   ```
-   cicd/tests/src/judge/
-   cicd/tests/src/reporter/
-   cicd/tests/testcases/{build,integration,e2e}/
-   cicd/scripts/
-   cicd/results/
-   ```
-
-2. **Copy selected files** from the template source directory into the target project
-
-3. **Adapt config.ts** with user's answers — replace placeholder values:
-   - `projectName: 'my-project'` → user's project name
-   - `sessionPrefix: 'test-session'` → `'{projectName}-session'`
-   - `llm.defaultUrl` → user's Ollama URL
-   - `llm.defaultModel` → user's model
-   - If MCP: set `mcp.serverCommand` to match their server
-
-4. **Adapt package.json** — if MCP client included, add `@modelcontextprotocol/sdk` to peerDependencies
-
-5. **Create .gitignore** in `cicd/results/`:
-   ```
-   *
-   !.gitignore
-   ```
-
-6. **Run `npm install`** in `cicd/tests/`
-
-#### Phase 5: Verify
-
-1. Run `cd cicd/tests && npm run build` — TypeScript must compile
-2. Run `npm run list` — test loader must work (shows example test cases if installed)
-3. If either fails, diagnose and fix before reporting success
-
-#### Phase 6: Report
-
-Show the user:
-- Summary of installed components (what was included/excluded and why)
-- Configuration values applied
-- Next steps:
-  - Write test cases in `cicd/tests/testcases/`
-  - Customize error patterns in `config.ts`
-  - Run tests: `cd cicd/tests && npm test -- --no-llm`
-
-### Updates
-
-To update an existing installation, run the same flow. The agent should:
-- Compare installed files against the template source (check for divergence)
-- Preserve the user's `config.ts` customizations, test cases, and error patterns
-- Only update framework files (judges, executor, loader, etc.)
-- Show what changed before applying updates
-
-### Manual Installation (Alternative)
-
+Manual alternative:
 ```bash
 make install TARGET=/path/to/project NAME=project-name
 cd /path/to/project/cicd/tests && npm install
-# Then manually edit config.ts
+# Edit config.ts for your project
 ```
 
 ## Core Commands
 
 ```bash
 cd cicd/tests
-npm run build           # TypeScript compile
-npm test                # Run all tests with LLM judge
-npm test -- --no-llm    # Run without LLM (faster)
-npm test -- --suite build  # Run specific suite
-npm test -- --id TC-001    # Run specific test
-npm test -- --dry-run      # Preview without executing
-npm run list            # List available tests
-```
-
-Install to a project:
-```bash
-make install TARGET=/path/to/project NAME=project-name
+npm run build                      # TypeScript compile
+npm test                           # Run all tests with LLM judge
+npm test -- --no-llm               # Run without LLM (faster)
+npm test -- --suite build          # Run specific suite
+npm test -- --id TC-001            # Run specific test
+npm test -- --tag auth             # Run tests tagged 'auth'
+npm test -- --dry-run              # Preview without executing
+npm run list                       # List available tests
+npm run list -- --tag auth         # List tests by tag
 ```
 
 ## Project Structure
@@ -135,94 +37,37 @@ make install TARGET=/path/to/project NAME=project-name
 ```
 cicd/tests/
 ├── src/
-│   ├── cli.ts            # CLI entry point (Commander)
-│   ├── config.ts         # Project configuration — customize per project
-│   ├── types.ts          # Core interfaces (TestCase, TestStep, etc.)
-│   ├── loader.ts         # YAML parser with dependency resolution
-│   ├── executor.ts       # Test execution with variable capture
-│   ├── mcp-client.ts     # MCP tool client for integration testing (optional)
-│   ├── log-collector.ts  # Docker log capture with test markers
-│   ├── judge/
-│   │   ├── simple-judge.ts  # Deterministic: exit codes, patterns, error detection
-│   │   └── llm-judge.ts     # Semantic: Ollama-based analysis with structured prompts
-│   └── reporter/
-│       ├── console.ts    # Colored terminal output
-│       └── json.ts       # Structured JSON for CI/CD
+│   ├── cli.ts              # CLI entry point (Commander)
+│   ├── config.ts           # Project configuration — customize per project
+│   ├── types.ts            # Core interfaces (TestCase, TestStep, etc.)
+│   ├── loader.ts           # YAML parser with dependency resolution
+│   ├── executor.ts         # Test execution with variable capture
+│   ├── mcp-client.ts       # MCP tool client (optional)
+│   ├── log-collector.ts    # Docker log capture (optional)
+│   ├── judge/              # Simple + LLM judges
+│   └── reporter/           # Console + JSON reporters
 ├── testcases/
-│   ├── build/            # TC-BUILD-*.yml
-│   ├── integration/      # TC-INTEGRATION-*.yml (or TC-INT-*.yml)
-│   └── e2e/              # TC-E2E-*.yml
+│   ├── build/              # TC-BUILD-*.yml
+│   ├── integration/        # TC-INT-*.yml
+│   └── e2e/                # TC-E2E-*.yml
 └── package.json
+
+.claude/
+├── skills/                 # /ci-testcase, /ci-run, /add-tool, /install, /review-docs-privacy
+└── rules/                  # test-yaml-format.md, workflow-patterns.md
 ```
 
-## Test Case YAML Format
+## Test Case YAML
 
-```yaml
-id: TC-SUITE-NNN
-name: Human-readable test name
-suite: build|integration|e2e
-goal: One-line objective for LLM judge context
-priority: 1                    # Lower = runs first
-timeout: 30000                 # Milliseconds
-dependencies: [TC-SUITE-001]   # Tests that must pass first
+See `.claude/rules/test-yaml-format.md` for full schema, variable capture syntax, and suite guidelines.
 
-steps:
-  - name: Step description
-    command: shell command to execute
-    timeout: 5000              # Optional, overrides test timeout
-    expectPatterns:            # All must match (regex)
-      - "pattern"
-    rejectPatterns:            # None should match (regex)
-      - "error"
-    capture:                   # Extract values from JSON output
-      varName: "json.path"
-
-criteria: |
-  Human-readable criteria for LLM judge evaluation.
-```
-
-## Variable Capture
-
-Steps can extract values from JSON output and inject them into later steps:
-
-```yaml
-steps:
-  - name: Create resource
-    command: curl -s -X POST http://localhost:3000/api/resources
-    capture:
-      resourceId: "id"
-  - name: Verify resource
-    command: curl -s http://localhost:3000/api/resources/{{resourceId}}
-```
-
-**Path syntax:**
-- `id` — direct field
-- `data.name` — nested field
-- `data[name=foo].id` — array find by field match
-- `$[type=user].email` — root array find
-
-MCP double-encoded responses (`content[0].text` wrapping) are automatically unwrapped.
-
-## MCP Client (Optional)
-
-For MCP server projects, `mcp-client.ts` spawns the server and calls tools:
-
-```bash
-npx tsx cicd/tests/src/mcp-client.ts <tool_name> '<json_args>'
-```
-
-Configure the server command:
-- Environment variable: `MCP_SERVER_COMMAND="node dist/mcpServer.js"`
-- Default in config.ts: `mcp.serverCommand`
-
-Requires `@modelcontextprotocol/sdk` (optional peer dependency — install in your project if needed).
+Key fields: `id`, `name`, `suite`, `steps`, `tags` (optional), `criteria`, `goal`, `dependencies`.
 
 ## Dual-Judge System
 
 Both judges must pass for a test to pass:
-
-- **Simple Judge**: Exit codes = 0, expectPatterns found, rejectPatterns absent, no ERROR_PATTERNS in logs
-- **LLM Judge**: Semantic analysis of output against `criteria` and `goal` fields using Ollama
+- **Simple Judge**: Exit codes, expectPatterns, rejectPatterns, ERROR_PATTERNS
+- **LLM Judge**: Semantic analysis via Ollama against `criteria` and `goal`
 
 Use `--no-llm` to skip LLM judging when Ollama is unavailable.
 
@@ -230,19 +75,41 @@ Use `--no-llm` to skip LLM judging when Ollama is unavailable.
 
 Edit `config.ts` per project:
 - `projectName` — used in LLM prompts
-- `llm.defaultUrl` / `llm.defaultModel` — Ollama endpoint
+- `SUITES` — extend with custom suite names (e.g., `runtime`, `inference`)
 - `ERROR_PATTERNS` / `ERROR_EXCLUSIONS` — project-specific error detection
 - `mcp.serverCommand` — MCP server startup command
+
+**Environment variables** (for CI, override without editing source):
+- `LLM_JUDGE_URL` — Ollama endpoint (default: `http://localhost:11434`)
+- `LLM_JUDGE_MODEL` — Model for judging (default: `llama3:8b`)
+
+**Separate judge instance:** If testing an Ollama instance, run the judge on a different port to avoid GPU contention.
+
+## MCP Client (Optional)
+
+For MCP server projects, `mcp-client.ts` spawns the server and calls tools:
+```bash
+npx tsx cicd/tests/src/mcp-client.ts <tool_name> '<json_args>'
+```
+Configure via `MCP_SERVER_COMMAND` env var or `config.ts` → `mcp.serverCommand`.
+
+## CI Workflows
+
+See `.claude/rules/workflow-patterns.md` for per-feature and suite-based workflow patterns.
+
+Template includes: `build.yml`, `test-run.yml`, `test-feature-example.yml`, `ci.yml` (recommended) and legacy `test-pipeline.yml`, `test-suite.yml`.
 
 ## Development Guidelines
 
 - Keep everything configurable via `config.ts` — never hardcode project-specific values
-- Template files are installed via agent-driven flow (see Installation section) or Makefile fallback
+- Template files are installed via agent-driven flow (`/install`) or Makefile fallback
 - Follow existing TypeScript patterns (strict types, async/await)
-- Test suites are configurable via `SUITES` array in config.ts
+- No hardcoded IPs, infrastructure IDs, or private repo references
 
-## CI Flow Commands
+## Skills
 
 - `/ci-testcase` — generate YAML test cases from requirements
 - `/ci-run` — execute tests with guided output
 - `/add-tool` — add new MCP tools following standard patterns
+- `/install` — install framework into a project
+- `/review-docs-privacy` — review for security and quality

--- a/Makefile
+++ b/Makefile
@@ -86,10 +86,16 @@ install: check
 	@# Copy CLAUDE.md if it exists
 	@if [ -f "$(TEMPLATE_DIR)/CLAUDE.md" ]; then cp "$(TEMPLATE_DIR)/CLAUDE.md" "$(TARGET)/CLAUDE.md"; fi
 
-	@# Copy Claude commands if they exist
-	@if [ -d "$(TEMPLATE_DIR)/.claude/commands" ]; then \
-		mkdir -p "$(TARGET)/.claude/commands"; \
-		cp "$(TEMPLATE_DIR)/.claude/commands/"*.md "$(TARGET)/.claude/commands/" 2>/dev/null || true; \
+	@# Copy Claude skills if they exist
+	@if [ -d "$(TEMPLATE_DIR)/.claude/skills" ]; then \
+		mkdir -p "$(TARGET)/.claude/skills"; \
+		cp -r "$(TEMPLATE_DIR)/.claude/skills/"* "$(TARGET)/.claude/skills/" 2>/dev/null || true; \
+	fi
+
+	@# Copy Claude rules if they exist
+	@if [ -d "$(TEMPLATE_DIR)/.claude/rules" ]; then \
+		mkdir -p "$(TARGET)/.claude/rules"; \
+		cp "$(TEMPLATE_DIR)/.claude/rules/"*.md "$(TARGET)/.claude/rules/" 2>/dev/null || true; \
 	fi
 
 	@# Create .gitignore for results
@@ -127,4 +133,8 @@ endif
 	@rm -rf "$(TARGET)/cicd"
 	@rm -f "$(TARGET)/.github/workflows/test-pipeline.yml"
 	@rm -f "$(TARGET)/.github/workflows/test-suite.yml"
+	@rm -f "$(TARGET)/.github/workflows/build.yml"
+	@rm -f "$(TARGET)/.github/workflows/test-run.yml"
+	@rm -f "$(TARGET)/.github/workflows/test-feature-example.yml"
+	@rm -f "$(TARGET)/.github/workflows/ci.yml"
 	@echo "Done."

--- a/README.md
+++ b/README.md
@@ -37,12 +37,15 @@ The framework is built around three core principles:
 
 - **Dual-Judge System**: Both simple (fast) and LLM (semantic) judges must pass
 - **YAML-Driven Tests**: Tests defined as configuration, not code
+- **Tag-Based Filtering**: Filter tests by feature tag via `--tag` for per-feature CI workflows
 - **Variable Capture**: Extract values from step output and pass to later steps via `{{variable}}`
+- **Environment Variable Substitution**: Variables fall back to `process.env` for CI-friendly patterns
 - **Dependency Resolution**: Tests can depend on other tests passing first
 - **Log Collection with Markers**: Precise extraction of logs per test from Docker streams
 - **MCP Client**: Test MCP server tools with configurable server command
-- **Claude Commands**: AI-assisted test authoring via `/ci-testcase`, `/ci-run`, `/add-tool`
-- **Installable Template**: Add to any project via `make install`
+- **Claude Skills**: AI-assisted test authoring via `/ci-testcase`, `/ci-run`, `/add-tool`
+- **Per-Feature CI Workflows**: Composable GitHub Actions with reusable test runner
+- **Installable Template**: Add to any project via `/install` or `make install`
 - **Flexible Output**: Console (colored) and JSON formats for CI consumption
 
 ## Architecture
@@ -64,7 +67,7 @@ The framework is built around three core principles:
   │     TestLoader      │  • Parse YAML test definitions
   │     (loader.ts)     │  • Validate required fields
   └─────────┬───────────┘  • Resolve dependencies
-            │
+            │              • Filter by suite or tag
             ▼
   ┌─────────────────────┐
   │   Dependency Sort   │  • Topological sort by dependencies
@@ -80,7 +83,8 @@ The framework is built around three core principles:
             │  • Run shell commands    │  • docker compose logs
             │  • Capture stdout/stderr │  • Test markers
             │  • Check patterns        │  • Per-test extraction
-            │                          │
+            │  • Substitute variables  │
+            │    (captured + env vars) │
             ▼                          ▼
      ┌─────────────────────────────────────┐
      │            TestResult[]             │
@@ -96,12 +100,12 @@ The framework is built around three core principles:
 │    │      Simple Judge       │         │       LLM Judge         │          │
 │    │    (simple-judge.ts)    │         │    (llm-judge.ts)       │          │
 │    ├─────────────────────────┤         ├─────────────────────────┤          │
-│    │ ✓ Exit code == 0        │         │ ✓ Semantic analysis     │          │
-│    │ ✓ Expected patterns     │         │ ✓ Criteria evaluation   │          │
-│    │ ✓ No rejected patterns  │         │ ✓ Context understanding │          │
-│    │ ✓ No error patterns     │         │ ✓ Evidence extraction   │          │
+│    │ Exit code == 0          │         │ Semantic analysis       │          │
+│    │ Expected patterns       │         │ Criteria evaluation     │          │
+│    │ No rejected patterns    │         │ Context understanding   │          │
+│    │ No error patterns       │         │ Evidence extraction     │          │
 │    ├─────────────────────────┤         ├─────────────────────────┤          │
-│    │ Speed: ⚡ Milliseconds   │         │ Speed: 🐢 Seconds       │          │
+│    │ Speed: Milliseconds     │         │ Speed: Seconds          │          │
 │    │ Mode: Deterministic     │         │ Mode: AI-powered        │          │
 │    └───────────┬─────────────┘         └───────────┬─────────────┘          │
 │                │                                   │                         │
@@ -117,8 +121,8 @@ The framework is built around three core principles:
                     ┌────────────────────────┐
                     │       Reporters        │
                     ├────────────────────────┤
-                    │ • ConsoleReporter      │  Colored terminal output
-                    │ • JsonReporter         │  Structured JSON files
+                    │ ConsoleReporter        │  Colored terminal output
+                    │ JsonReporter           │  Structured JSON files
                     └────────────┬───────────┘
                                  │
                                  ▼
@@ -138,11 +142,11 @@ Traditional tests only check exit codes. A process can exit with code 0 but prod
 
 | Scenario | Exit Code | Simple Judge | LLM Judge |
 |----------|-----------|--------------|-----------|
-| Command fails | 1 | ❌ Catches | ❌ Catches |
-| "Error" in output | 0 | ❌ Catches | ❌ Catches |
-| Wrong output format | 0 | ✅ Misses | ❌ Catches |
-| Incomplete results | 0 | ✅ Misses | ❌ Catches |
-| Semantic mismatch | 0 | ✅ Misses | ❌ Catches |
+| Command fails | 1 | Catches | Catches |
+| "Error" in output | 0 | Catches | Catches |
+| Wrong output format | 0 | Misses | Catches |
+| Incomplete results | 0 | Misses | Catches |
+| Semantic mismatch | 0 | Misses | Catches |
 
 The LLM judge reads the criteria from YAML and evaluates whether the actual output semantically satisfies the requirements—catching failures that pattern matching alone would miss.
 
@@ -186,17 +190,20 @@ make clean TARGET=/path/to/project           # Remove framework from project
 Edit `cicd/tests/src/config.ts` in your project:
 
 ```typescript
+// Extend with custom suite names for your project
+export const SUITES: string[] = ['build', 'integration', 'e2e'];
+
 export const CONFIG = {
   projectName: 'your-project',
   
-  // Ollama LLM Judge settings
+  // LLM Judge settings (overridable via env vars)
   llm: {
-    defaultUrl: 'http://localhost:11434',  // ← Your Ollama URL
-    defaultModel: 'llama3:8b',             // ← Your model
+    defaultUrl: process.env.LLM_JUDGE_URL || 'http://localhost:11434',
+    defaultModel: process.env.LLM_JUDGE_MODEL || 'llama3:8b',
     timeout: 300000,
-    stdoutLimit: 1000,                     // ← Max stdout chars per step in prompt
-    stderrLimit: 500,                      // ← Max stderr chars per step in prompt
-    logsLimit: 3000,                       // ← Max container log chars in prompt
+    stdoutLimit: 1000,
+    stderrLimit: 500,
+    logsLimit: 3000,
   },
 };
 
@@ -208,6 +215,17 @@ export const ERROR_PATTERNS: RegExp[] = [
 ];
 ```
 
+### Environment Variables
+
+For CI environments, override LLM judge settings without editing source:
+
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `LLM_JUDGE_URL` | Ollama endpoint | `http://localhost:11434` |
+| `LLM_JUDGE_MODEL` | Model for judging | `llama3:8b` |
+
+**Tip:** If your project tests an Ollama instance (port 11434), run the LLM judge on a separate port (e.g., 11435) to avoid GPU memory contention.
+
 ## Running Tests
 
 ```bash
@@ -217,12 +235,61 @@ npm test                    # Run all tests with LLM judge
 npm test -- --no-llm        # Run without LLM (faster)
 npm test -- --suite build   # Run specific suite
 npm test -- --id TC-001     # Run specific test
+npm test -- --tag auth      # Run tests tagged 'auth'
 npm test -- --dry-run       # Preview what would run
 npm run list                # List available tests
+npm run list -- --tag auth  # List tests by tag
 
-# Override Ollama URL
+# Override Ollama settings via CLI
 npm test -- --judge-url http://host:11434 --judge-model gemma3:12b
 ```
+
+## CI Workflow Patterns
+
+The template includes composable GitHub Actions workflows:
+
+```
+.github/workflows/
+├── build.yml                # Standalone build step
+├── test-run.yml             # Reusable test runner (supports --tag and --suite)
+├── test-feature-example.yml # Example per-feature workflow (~25 lines)
+├── ci.yml                   # Full pipeline: build -> tests in parallel
+├── test-pipeline.yml        # Legacy suite-based pipeline
+└── test-suite.yml           # Legacy reusable suite runner
+```
+
+### Per-Feature Pattern (Recommended)
+
+Each feature gets a thin workflow file that delegates to `test-run.yml`:
+
+```yaml
+# .github/workflows/test-auth.yml
+name: "Test: Auth"
+on:
+  workflow_dispatch:
+    inputs:
+      judge_mode:
+        type: choice
+        options: ["simple", "dual"]
+  workflow_call:
+    inputs:
+      judge_mode:
+        type: string
+jobs:
+  test:
+    uses: ./.github/workflows/test-run.yml
+    with:
+      tag: auth
+      judge_mode: ${{ inputs.judge_mode }}
+```
+
+**Adding a new feature test:**
+1. Tag your test cases: `tags: [my-feature]`
+2. Copy `test-feature-example.yml` to `test-my-feature.yml`
+3. Change the `tag` value
+4. Add as a job in `ci.yml`
+
+Configure `LLM_JUDGE_URL` and `LLM_JUDGE_MODEL` as GitHub repository variables (`Settings > Variables > Actions`).
 
 ## MCP Testing
 
@@ -250,17 +317,19 @@ steps:
 
 Requires `@modelcontextprotocol/sdk` (install in your project: `npm install @modelcontextprotocol/sdk`).
 
-## Claude Commands
+## Claude Skills
 
 AI-assisted workflows via Claude Code slash commands:
 
-| Command | Purpose |
-|---------|---------|
+| Skill | Purpose |
+|-------|---------|
 | `/ci-testcase` | Generate YAML test cases from requirements |
 | `/ci-run` | Execute tests with guided output |
 | `/add-tool` | Add new MCP tools following standard patterns |
+| `/install` | Install framework into a project |
+| `/review-docs-privacy` | Review for security and documentation quality |
 
-These are installed to `.claude/commands/` by `make install`.
+These are installed to `.claude/skills/` by the install flow.
 
 ## Writing Test Cases
 
@@ -273,6 +342,7 @@ suite: build
 priority: 1
 timeout: 60000
 dependencies: []
+tags: [build, compile]
 
 steps:
   - name: Install dependencies
@@ -290,9 +360,19 @@ criteria: |
   Verify the project builds without errors.
 ```
 
+### Tags
+
+Tags enable per-feature filtering and CI workflow splitting:
+
+```yaml
+tags: [auth, api]          # Feature tags
+tags: [build, compile]     # Suite-aligned tags
+tags: [smoke]              # Test category tags
+```
+
 ### Variable Capture
 
-Steps can capture values from JSON output and pass them to later steps using `{{variable}}` substitution:
+Steps can capture values from JSON output and pass them to later steps using `{{variable}}` substitution. Variables resolve from captured step output first, then fall back to `process.env`:
 
 ```yaml
 id: TC-INT-002
@@ -301,6 +381,7 @@ suite: integration
 goal: Verify resource creation and retrieval
 timeout: 30000
 dependencies: []
+tags: [api, resources]
 
 steps:
   - name: Create resource
@@ -336,10 +417,14 @@ MCP tool responses (double-encoded JSON in `content[0].text`) are automatically 
 ```
 your-project/
 ├── CLAUDE.md                    # AI agent guidance
-├── .claude/commands/
-│   ├── ci-testcase.md           # /ci-testcase — generate test cases
-│   ├── ci-run.md                # /ci-run — execute tests
-│   └── add-tool.md              # /add-tool — add MCP tools
+├── .claude/
+│   ├── skills/                  # AI-assisted workflows
+│   │   ├── ci-testcase/         # /ci-testcase — generate test cases
+│   │   ├── ci-run/              # /ci-run — execute tests
+│   │   └── add-tool/            # /add-tool — add MCP tools
+│   └── rules/                   # Context-aware rules
+│       ├── test-yaml-format.md  # YAML schema reference
+│       └── workflow-patterns.md # CI workflow design patterns
 ├── cicd/
 │   ├── tests/
 │   │   ├── src/
@@ -362,8 +447,12 @@ your-project/
 │   │   └── format-results.sh
 │   └── results/
 └── .github/workflows/
-    ├── test-pipeline.yml
-    └── test-suite.yml
+    ├── build.yml                # Standalone build
+    ├── test-run.yml             # Reusable test runner
+    ├── test-feature-example.yml # Per-feature template
+    ├── ci.yml                   # Full pipeline orchestrator
+    ├── test-pipeline.yml        # Legacy pipeline
+    └── test-suite.yml           # Legacy suite runner
 ```
 
 ## License

--- a/cicd/tests/src/cli.ts
+++ b/cicd/tests/src/cli.ts
@@ -32,6 +32,7 @@ program
   .description('Run test cases')
   .option('-s, --suite <suite>', 'Run only tests from this suite')
   .option('-i, --id <id>', 'Run only the test with this ID')
+  .option('-t, --tag <tag>', 'Run only tests with this tag')
   .option('--dry-run', 'Show what would run without executing', false)
   .option('--no-llm', 'Skip LLM judging (simple judge only)')
   .option('--judge-url <url>', 'Ollama URL for LLM judge', CONFIG.llm.defaultUrl)
@@ -59,6 +60,7 @@ program
     const config: RunConfig = {
       suite: options.suite,
       testId: options.id,
+      tag: options.tag,
       dryRun: options.dryRun,
       noLlm: !options.llm,
       judgeUrl: options.judgeUrl,
@@ -93,6 +95,10 @@ program
 
     if (config.testId) {
       filteredTestCases = filteredTestCases.filter((tc) => tc.id === config.testId);
+    }
+
+    if (config.tag) {
+      filteredTestCases = filteredTestCases.filter((tc) => tc.tags?.includes(config.tag!));
     }
 
     if (filteredTestCases.length === 0) {
@@ -183,6 +189,7 @@ program
   .command('list')
   .description('List available test cases')
   .option('-s, --suite <suite>', 'Filter by suite')
+  .option('-t, --tag <tag>', 'Filter by tag')
   .action(async (options) => {
     const testsDir = path.dirname(new URL(import.meta.url).pathname);
     const testcasesDir = path.join(testsDir, '..', 'testcases');
@@ -192,6 +199,10 @@ program
 
     if (options.suite) {
       testCases = testCases.filter((tc) => tc.suite === options.suite);
+    }
+
+    if (options.tag) {
+      testCases = testCases.filter((tc) => tc.tags?.includes(options.tag));
     }
 
     testCases = loader.sortByDependencies(testCases);
@@ -205,6 +216,9 @@ program
       for (const tc of cases) {
         console.log(`  ${tc.id}: ${tc.name}`);
         console.log(`    Priority: ${tc.priority}, Timeout: ${tc.timeout}ms`);
+        if (tc.tags && tc.tags.length > 0) {
+          console.log(`    Tags: ${tc.tags.join(', ')}`);
+        }
         if (tc.dependencies.length > 0) {
           console.log(`    Depends on: ${tc.dependencies.join(', ')}`);
         }

--- a/cicd/tests/src/config.ts
+++ b/cicd/tests/src/config.ts
@@ -5,10 +5,11 @@
  */
 
 /**
- * Available test suites - extend this for your project.
+ * Available test suites - extend this array for your project.
+ * Examples: ['build', 'integration', 'e2e'] or ['build', 'runtime', 'inference', 'models']
  */
-export const SUITES = ['build', 'integration', 'e2e'] as const;
-export type Suite = typeof SUITES[number];
+export const SUITES: string[] = ['build', 'integration', 'e2e'];
+export type Suite = string;
 
 /**
  * Project configuration.
@@ -26,8 +27,8 @@ export const CONFIG = {
   
   // LLM Judge defaults
   llm: {
-    defaultUrl: 'http://localhost:11434',
-    defaultModel: 'llama3:8b',
+    defaultUrl: process.env.LLM_JUDGE_URL || 'http://localhost:11434',
+    defaultModel: process.env.LLM_JUDGE_MODEL || 'llama3:8b',
     timeout: 300000,
     stdoutLimit: 1000,
     stderrLimit: 500,

--- a/cicd/tests/src/executor.ts
+++ b/cicd/tests/src/executor.ts
@@ -39,7 +39,7 @@ export class TestExecutor {
 
   private substituteVariables(command: string): string {
     return command.replace(/\{\{(\w+)\}\}/g, (match, varName) => {
-      const value = this.variables[varName];
+      const value = this.variables[varName] ?? process.env[varName];
       if (value === undefined) {
         this.progress(`    [WARN] Variable {{${varName}}} not found`);
         return match;

--- a/cicd/tests/src/loader.ts
+++ b/cicd/tests/src/loader.ts
@@ -62,6 +62,14 @@ export class TestLoader {
   }
 
   /**
+   * Load test cases filtered by tag.
+   */
+  async loadByTag(tag: string): Promise<TestCase[]> {
+    const all = await this.loadAll();
+    return all.filter((tc) => tc.tags?.includes(tag));
+  }
+
+  /**
    * Sort test cases by dependencies using topological sort.
    * Tests with lower priority numbers run first within dependency constraints.
    */
@@ -213,6 +221,7 @@ export class TestLoader {
       priority: typeof raw.priority === 'number' ? raw.priority : 1,
       timeout: typeof raw.timeout === 'number' ? raw.timeout : CONFIG.defaultTimeout,
       dependencies: Array.isArray(raw.dependencies) ? raw.dependencies : [],
+      tags: Array.isArray(raw.tags) ? raw.tags.map(String) : [],
       steps,
       goal: typeof raw.goal === 'string' ? raw.goal : undefined,
       criteria: typeof raw.criteria === 'string' ? raw.criteria : '',

--- a/cicd/tests/src/types.ts
+++ b/cicd/tests/src/types.ts
@@ -40,6 +40,8 @@ export interface TestCase {
   timeout: number;
   /** Test IDs that must pass before this test runs */
   dependencies: string[];
+  /** Tags for filtering (e.g., feature name, capability area) */
+  tags?: string[];
   /** Test steps to execute */
   steps: TestStep[];
   /** Human-readable criteria for LLM judge evaluation */
@@ -217,6 +219,8 @@ export interface RunConfig {
   suite?: string;
   /** Filter by specific test ID */
   testId?: string;
+  /** Filter by tag */
+  tag?: string;
   /** Show what would run without executing */
   dryRun: boolean;
   /** Skip LLM judging (simple judge only) */

--- a/cicd/tests/src/types.ts
+++ b/cicd/tests/src/types.ts
@@ -245,7 +245,5 @@ export interface RunConfig {
 export const DEFAULT_CONFIG: Partial<RunConfig> = {
   dryRun: false,
   noLlm: false,
-  judgeUrl: 'http://localhost:11434',
-  judgeModel: 'llama3:8b',
   outputFormat: 'console',
 };

--- a/cicd/tests/testcases/build/TC-BUILD-001.yml
+++ b/cicd/tests/testcases/build/TC-BUILD-001.yml
@@ -7,6 +7,7 @@ suite: build
 priority: 1
 timeout: 120000
 dependencies: []
+tags: [build, compile]
 
 steps:
   - name: Check Node.js version

--- a/cicd/tests/testcases/build/TC-BUILD-002.yml
+++ b/cicd/tests/testcases/build/TC-BUILD-002.yml
@@ -5,6 +5,7 @@ priority: 2
 timeout: 60000
 dependencies:
   - TC-BUILD-001
+tags: [build, lint]
 
 steps:
   - name: Run linter

--- a/cicd/tests/testcases/e2e/TC-E2E-001.yml
+++ b/cicd/tests/testcases/e2e/TC-E2E-001.yml
@@ -5,6 +5,7 @@ priority: 1
 timeout: 60000
 dependencies:
   - TC-INTEGRATION-001
+tags: [e2e, lifecycle]
 
 steps:
   - name: Run E2E tests

--- a/cicd/tests/testcases/integration/TC-INTEGRATION-001.yml
+++ b/cicd/tests/testcases/integration/TC-INTEGRATION-001.yml
@@ -5,6 +5,7 @@ priority: 1
 timeout: 30000
 dependencies:
   - TC-BUILD-001
+tags: [integration, health]
 
 steps:
   - name: Start services


### PR DESCRIPTION
## Summary

- Add `tags` field to test cases and `--tag` CLI option for per-feature filtering (from ruckus1-mcp PR #34)
- Add `process.env` fallback in executor `substituteVariables()` for CI-friendly `{{ENV_VAR}}` patterns
- Add `LLM_JUDGE_URL`/`LLM_JUDGE_MODEL` env var support (verified in both ruckus1-mcp and ollama37)
- Create per-feature workflow templates (`build.yml`, `test-run.yml`, `test-feature-example.yml`, `ci.yml`)
- Migrate `.claude/commands/` to `.claude/skills/` with YAML frontmatter per Anthropic's official docs
- Create `.claude/rules/` for test YAML format and workflow pattern documentation
- Slim CLAUDE.md from 248 to 115 lines (under 200-line recommendation)
- Make `SUITES` extensible for custom suite names (e.g., ollama37's `runtime`, `inference`, `models`)

Fixes #13

## Research

Verified all backport items against source repos:
- **ruckus1-mcp**: PR #34 (tags, workflows), commits `dee04e8` (LLM env vars), `041da2c` (env var substitution)
- **ollama37**: Studied CI patterns — suite-based workflows, separate judge port, extensible suites
- **Anthropic docs**: Skills format, CLAUDE.md best practices, rules with path-based loading

## Test plan

- [x] `npm run build` — TypeScript compiles
- [x] `npm run list` — shows tags for each test case
- [x] `npm test -- --tag build --dry-run` — filters to build-tagged tests only
- [x] `npm test -- --dry-run` — all tests (backwards compatible)
- [x] `wc -l CLAUDE.md` — 115 lines (under 200)
- [x] No leaked references (`grep -r 'ruckus\|192.168'` clean)
- [ ] Skills accessible as `/ci-testcase`, `/ci-run`, `/add-tool`, `/install`, `/review-docs-privacy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)