### PR TITLE
STORY-001: simple-by-default LLM judge + reconcile tooling

### DIFF
--- a/.claude/commands/dev-workflow/dw-create-pr.md
+++ b/.claude/commands/dev-workflow/dw-create-pr.md
@@ -1,0 +1,97 @@
+# Create a Pull Request
+
+```
+Push branch and open a pull request with issue linkage.
+
+Issue number: {{input}}
+
+## PURPOSE
+
+Creates a pull request for the current branch, linking it to the GitHub Issue
+via "Fixes #N" for auto-closure. Updates issue labels to reflect PR status.
+
+---
+
+## WORKFLOW
+
+    /dw-create-pr 27
+        │
+        ├─► Step 1: Verify Readiness
+        │   - Confirm you're on the correct branch (issue-<N>-<slug>)
+        │   - Run: git status — check for uncommitted changes
+        │   - Review the branch's commits against the repo's default branch —
+        │     derive it, don't hardcode `main` (gh repo view --json
+        │     defaultBranchRef -q .defaultBranchRef.name):
+        │     git log --oneline <default>..HEAD
+        │   - If no argument given, infer issue number from branch name
+        │   - Run: gh issue view <N> — check if title contains [STORY-XXX]
+        │
+        ├─► Step 2: Push Branch
+        │   - Run: git push -u origin $(git branch --show-current)
+        │
+        ├─► Step 3: Create PR
+        │   - Title: short, imperative, under 70 characters
+        │   - Body must include "Fixes #N" or "Closes #N"
+        │   - Use this template:
+        │
+        │       gh pr create --title "<title>" --body "$(cat <<'EOF'
+        │       ## Summary
+        │       <1-3 bullet points>
+        │
+        │       Fixes #<issue-number>
+        │       (if linked to story: "Part of STORY-XXX")
+        │
+        │       ## Test plan
+        │       - [ ] ...
+        │
+        │       Generated with [Claude Code](https://claude.com/claude-code)
+        │       EOF
+        │       )"
+        │
+        ├─► Step 4: Update Issue Labels
+        │   - Run: gh issue edit <N> --remove-label "status:in-progress" \
+        │          --add-label "status:needs-review"
+        │   - Comment on issue:
+        │     gh issue comment <N> --body "PR #<PR> created. Summary: <what changed>"
+        │
+        ├─► Step 5: Update Story File (if linked)
+        │   - If the issue title contains [STORY-XXX]:
+        │     update docs/stories/STORY-XXX.md status to reflect PR is open
+        │   - Skip silently if no story link or docs/stories/ doesn't exist
+        │
+        └─► Step 6: Report
+            - Show the PR URL to the user
+            - Stop here — don't auto-advance. The PR now waits for a HUMAN to
+              review and test it. Merge with /dw-merge <PR> only once a human is
+              satisfied. (The change's substance was already gated locally by
+              /dw-review-implement before the PR.)
+
+---
+
+## EXAMPLE
+
+    /dw-create-pr 27
+
+**Agent verifies, pushes, creates PR:**
+
+    $ git status
+    $ git log --oneline <default-branch>..HEAD
+    $ git push -u origin issue-27-release-notes
+    $ gh pr create --title "Add release notes generator command" --body "..."
+    $ gh issue edit 27 --remove-label "status:in-progress" --add-label "status:needs-review"
+    $ gh issue comment 27 --body "PR #30 created."
+
+**Output:**
+
+    PR #30 created: https://github.com/owner/repo/pull/30
+    A human reviews + tests it; merge with /dw-merge 30 when satisfied.
+
+---
+
+## API Notes
+
+- Uses `gh` CLI for PR and issue operations
+- `Fixes #N` in PR body auto-closes the issue when PR is merged
+- Copy relevant labels from the issue to the PR if needed
+- If branch is already pushed, the push step is a no-op
+```

--- a/.claude/commands/dev-workflow/dw-implement.md
+++ b/.claude/commands/dev-workflow/dw-implement.md
@@ -1,0 +1,117 @@
+# Implement a GitHub Issue
+
+```
+Start work on a GitHub Issue — create branch, implement, and track progress.
+
+Issue number: {{input}}
+
+## PURPOSE
+
+Picks up a GitHub Issue and drives it through implementation. Creates a feature
+branch, tracks status via labels and comments, handles failures transparently,
+and prepares for PR creation when done.
+
+---
+
+## WORKFLOW
+
+    /dw-implement 27
+        │
+        ├─► Step 1: Understand the Issue
+        │   - Run: gh issue view <N>
+        │   - Read acceptance criteria, technical notes, dependencies
+        │   - Check labels — type and priority should already be set
+        │   - Check for linked/blocking issues
+        │   - If issue title contains [STORY-XXX], read docs/stories/STORY-XXX.md
+        │     for full context (the user story and the need it serves)
+        │   - If anything is unclear, ask the user before starting
+        │
+        ├─► Step 2: Create Branch
+        │   - Branch name: issue-<N>-<short-slug>
+        │     Example: issue-27-release-notes
+        │   - Branch from the repo's default branch — derive it, don't hardcode
+        │     `main` (e.g. gh repo view --json defaultBranchRef -q
+        │     .defaultBranchRef.name); check it out and pull, then:
+        │     git checkout -b issue-<N>-<slug>
+        │   - Comment on issue:
+        │     gh issue comment <N> --body "Starting work on branch \`issue-<N>-<slug>\`"
+        │   - Add status label:
+        │     gh issue edit <N> --add-label "status:in-progress"
+        │
+        ├─► Step 3: Implement
+        │   - Make the changes based on acceptance criteria
+        │   - Build and test using the project's standard tooling
+        │     (Makefile, test framework, CI pipeline — whatever the project uses)
+        │   - Commit incrementally with clear messages
+        │
+        ├─► Step 4a: On Success
+        │   - Comment on issue:
+        │     gh issue comment <N> --body "Implementation complete, tests passing. Ready for PR."
+        │   - Progress is recorded on the issue, not the story — the story stays the
+        │     stable statement of the need
+        │   - Proceed to /dw-review-implement to gate the changes before the PR
+        │
+        ├─► Step 4b: On Failure
+        │   - Do NOT silently retry — update the issue:
+        │     gh issue comment <N> --body "Build/test failure: <what failed, error, root cause>"
+        │   - If blocked, add label:
+        │     gh issue edit <N> --add-label "status:blocked"
+        │   - Investigate, fix, update issue:
+        │     gh issue comment <N> --body "Applied fix: <what changed>. Retesting."
+        │   - Remove blocked label after unblocking:
+        │     gh issue edit <N> --remove-label "status:blocked"
+        │   - If stuck after 2-3 attempts, comment blockers and ask the user
+        │
+        └─► Step 4c: On Partial Fix
+            - Comment: what was fixed, what remains, blockers
+            - If the partial fix is independently useful: run /dw-review-implement,
+              then a human reviews + tests before a PR is opened (/dw-create-pr)
+            - Create follow-up issues for remaining work
+
+---
+
+## ISSUE CROSS-REFERENCES
+
+Use these patterns in issue comments and PR bodies:
+- **Parent/child**: "Part of #N" or "Parent: #N"
+- **Dependencies**: "Depends on #N", "Blocked by #N"
+- **Related**: "Related to #N"
+
+GitHub auto-creates backlinks when issues reference each other.
+
+---
+
+## EXAMPLE
+
+    /dw-implement 27
+
+**Agent reads issue #27, creates branch, implements:**
+
+    $ gh issue view 27
+    $ git checkout -b issue-27-release-notes   # from the repo's default branch
+    $ gh issue comment 27 --body "Starting work on branch `issue-27-release-notes`"
+    $ gh issue edit 27 --add-label "status:in-progress"
+
+    ... (implementation work) ...
+
+    $ gh issue comment 27 --body "Implementation complete, tests passing. Ready for PR."
+
+**Next step:** /dw-review-implement 27 (local gate). Then a human reviews + tests
+before a PR is opened (/dw-create-pr 27) — the workflow doesn't auto-advance to a PR.
+
+---
+
+## KEY PRINCIPLE
+
+The issue is the single source of truth. Anyone reading it should see the full
+history — start, failures, fixes, and resolution.
+
+---
+
+## API Notes
+
+- Uses `gh` CLI for issue operations
+- Branch naming convention: `issue-<number>-<short-slug>`
+- Always comment on the issue before and after implementation
+- Label management: `status:in-progress` while working, `status:blocked` if stuck
+```

--- a/.claude/commands/dev-workflow/dw-merge.md
+++ b/.claude/commands/dev-workflow/dw-merge.md
@@ -1,0 +1,91 @@
+# Merge a Pull Request
+
+```
+Merge an approved pull request and clean up.
+
+PR number: {{input}}
+
+## PURPOSE
+
+Merges an approved PR, deletes the remote branch, cleans up local branches
+and issue labels. The linked issue auto-closes via "Fixes #N" in the PR body.
+
+---
+
+## WORKFLOW
+
+    /dw-merge 30
+        │
+        ├─► Step 1: Verify Ready to Merge
+        │   - Run: gh pr view <PR> --json mergeStateStatus,headRefName,reviewDecision
+        │   - Must be mergeable (no conflicts)
+        │   - Run: gh pr checks <PR> — any CI checks must pass (if applicable)
+        │   - The merge gate is HUMAN review + test, not a GitHub approval. On a
+        │     solo repo GitHub blocks self-approval, so do NOT require
+        │     reviewDecision=APPROVED. Before merging, confirm a human has reviewed
+        │     and tested the change (its substance was gated by /dw-review-implement
+        │     before the PR). If not yet reviewed/tested, stop and say so.
+        │
+        ├─► Step 2: Identify Linked Issue and Story
+        │   - Read PR body for "Fixes #N" or "Closes #N"
+        │   - Note the issue number for label cleanup
+        │   - Check if PR body or issue title contains [STORY-XXX] or "Part of STORY-XXX"
+        │
+        ├─► Step 3: Merge
+        │   - Run: gh pr merge <PR> --merge --delete-branch
+        │   - Uses --merge (not squash/rebase) to preserve commit history
+        │   - --delete-branch cleans up the remote branch
+        │
+        ├─► Step 4: Clean Up Issue Labels
+        │   - Run: gh issue edit <N> --remove-label "status:needs-review"
+        │   - Issue auto-closes via "Fixes #N" — no manual close needed
+        │
+        ├─► Step 5: Update Story File (if linked)
+        │   - If linked to STORY-XXX and docs/stories/STORY-XXX.md exists:
+        │     • Check off completed acceptance criteria for this task
+        │     • If all story tasks are closed, mark story status as Completed
+        │   - Skip silently if no story link or docs/stories/ doesn't exist
+        │
+        ├─► Step 6: Clean Up Local Branch
+        │   - Switch to the repo's default branch and pull — derive it, don't
+        │     hardcode `main` (gh repo view --json defaultBranchRef -q
+        │     .defaultBranchRef.name): git checkout <default> && git pull
+        │   - Run: git branch -d <branch-name>
+        │
+        └─► Step 7: Report
+            - Confirm merge to the user
+            - Show the merged PR URL
+            - If story has remaining open tasks, suggest: /dw-implement <next-issue>
+            - If story is complete, mention it
+            - Mention any follow-up issues if applicable
+
+---
+
+## EXAMPLE
+
+    /dw-merge 30
+
+**Agent verifies, merges, cleans up:**
+
+    $ gh pr view 30 --json mergeStateStatus,headRefName,reviewDecision  # mergeable? (don't gate on self-approval)
+    $ gh pr checks 30
+    $ gh pr merge 30 --merge --delete-branch
+    $ gh issue edit 27 --remove-label "status:needs-review"
+    $ git checkout <default-branch> && git pull
+    $ git branch -d issue-27-release-notes
+
+**Output:**
+
+    PR #30 merged: https://github.com/owner/repo/pull/30
+    Issue #27 auto-closed.
+    Branch issue-27-release-notes deleted (local + remote).
+
+---
+
+## API Notes
+
+- Uses `gh` CLI for PR and issue operations
+- `--merge` preserves full commit history (use `--squash` only if the project convention requires it)
+- `--delete-branch` removes the remote branch; `git branch -d` removes the local one
+- If PR is not approved or CI fails, report the blocker instead of merging
+```

--- a/.claude/commands/dev-workflow/dw-plan.md
+++ b/.claude/commands/dev-workflow/dw-plan.md
@@ -1,0 +1,129 @@
+# Plan Development Work into GitHub Issues
+
+```
+Break down a user request into GitHub Issues with labels and priorities.
+
+Request: {{input}}
+
+## PURPOSE
+
+Analyzes a feature request, enhancement, or bug report and creates well-structured
+GitHub Issues with proper labels and priorities. Checks for duplicates, breaks down
+multi-part requests, and waits for user approval before implementation begins.
+
+---
+
+## WORKFLOW
+
+    /dw-plan Add cross-repo sync commands
+        │
+        ├─► Step 1: Check Existing Issues
+        │   - Run: gh issue list --state all --limit 50
+        │   - Scan for duplicates or related issues
+        │   - If duplicate found, report and ask user how to proceed
+        │
+        ├─► Step 2: Classify the Request
+        │   - Determine type: feature / enhancement / bug / docs
+        │   - Determine priority: high / medium / low
+        │   - Break down into individual issues if request covers multiple items
+        │
+        ├─► Step 3: Create Labels (idempotent)
+        │   - Ensure type labels exist:
+        │     • feature        (color: #0e8a16) — New capability
+        │     • enhancement    (color: #1d76db) — Improve existing
+        │     • bug            (color: #d93f0b) — Bug report
+        │     • docs           (color: #c5def5) — Documentation
+        │   - Ensure priority labels exist:
+        │     • priority:high   (color: #b60205) — Important, fix soon
+        │     • priority:medium (color: #fbca04) — Normal priority
+        │     • priority:low    (color: #0e8a16) — Nice to have
+        │   - Ensure status labels exist:
+        │     • status:in-progress  (color: #1d76db) — Work started
+        │     • status:needs-review (color: #e4e669) — PR open, awaiting review
+        │     • status:blocked      (color: #d93f0b) — Blocked by dependency
+        │   - Use: gh label create "<name>" --color "<hex>" --description "<desc>" --force
+        │
+        ├─► Step 4: Create Issues
+        │   - One issue per distinct work item
+        │   - Use the appropriate body template (see below)
+        │   - Apply type + priority labels
+        │   - Link related issues: "Depends on #N", "Related to #N"
+        │
+        ├─► Step 5: Summarize
+        │   - Output a table of created issues:
+        │     | Issue | Title | Type | Priority | URL |
+        │   - Wait for user approval before proceeding
+        │
+        └─► Step 6: User Approval Gate
+            - Ask: "Want me to start on #N?"
+            - Do NOT proceed to /dw-implement until user explicitly approves
+
+---
+
+## ISSUE BODY TEMPLATES
+
+### Feature / Enhancement
+
+    ## User Story
+    As a [role], I want [capability], so that [benefit].
+
+    ## Acceptance Criteria
+    1. ...
+
+    ## Technical Notes
+    - ...
+
+    ## Dependencies
+    - None | Depends on #N
+
+### Bug
+
+    ## Description
+    ...
+
+    ## Expected Behavior
+    ...
+
+    ## Steps to Reproduce
+    1. ...
+
+---
+
+## EXAMPLE
+
+    /dw-plan Add command to generate release notes from git history
+
+**Agent creates:**
+
+    gh issue create \
+      --label "feature" --label "priority:medium" \
+      --title "Add release notes generator command" \
+      --body "## User Story
+    As a developer, I want to generate release notes from git history,
+    so that I can quickly summarize changes for each release.
+
+    ## Acceptance Criteria
+    1. Command reads git log between two tags
+    2. Groups commits by type (feature, fix, docs)
+    3. Outputs formatted markdown
+
+    ## Dependencies
+    - None"
+
+**Output:**
+
+    | Issue | Title                              | Type    | Priority | URL                    |
+    |-------|------------------------------------|---------|----------|------------------------|
+    | #27   | Add release notes generator command | feature | medium   | https://github.com/... |
+
+    Want me to start on #27?
+
+---
+
+## API Notes
+
+- Uses `gh` CLI — must be authenticated (`gh auth status`)
+- Labels use `--force` flag so existing labels are updated, not duplicated
+- Always check for duplicates before creating new issues
+- The issue body is the single source of truth for the work item
+```

--- a/.claude/commands/dev-workflow/dw-review-implement.md
+++ b/.claude/commands/dev-workflow/dw-review-implement.md
@@ -1,0 +1,115 @@
+# Review an Implementation
+
+```
+Review the changes an issue was implemented with — do they deliver the issue, and
+do they stay surgical rather than sprawling beyond it?
+
+Issue number: {{input}}
+
+## PURPOSE
+
+Quality-gates the work done by `/dw-implement` before it becomes a PR. Checks that
+the changes on the branch **deliver the issue** (every "Done When" is actually
+satisfied) and stay **surgical** (every changed line traces to the issue — no scope
+creep, dead code, or debug leftovers) while **fitting the studio**. Fixes small
+findings on the branch in place, or hands back to `/dw-implement` if the approach is
+wrong.
+
+Fits between `/dw-implement` (does the work) and `/dw-create-pr` (opens the PR):
+
+    … → dw-implement → dw-review-implement → dw-create-pr → …
+
+---
+
+## WORKFLOW
+
+    /dw-review-implement 27
+        │
+        ├─► Step 1: Gather
+        │   - Run: gh issue view <N> (the Goal + "Done When")
+        │   - If the title contains [STORY-XXX], read docs/stories/STORY-XXX.md
+        │     for the need behind the issue
+        │   - See what changed on the branch, against the repo's default branch:
+        │     git diff <default>...HEAD   (derive <default>, don't hardcode `main`)
+        │   - If there are no changes, report and stop (run /dw-implement first)
+        │
+        ├─► Step 2: Delivers the issue
+        │   - [ ] Every "Done When" box is actually satisfied by the changes —
+        │         observable, not asserted. Confirm by running the project's
+        │         standard tooling (build / test / render — whatever /dw-implement
+        │         used), not by reading the diff alone
+        │   - [ ] Nothing the issue asked for is missing or stubbed out
+        │   - [ ] The changes match the issue's Goal, not a different problem
+        │
+        ├─► Step 3: Surgical
+        │   - [ ] Every changed line traces to this issue — no unrelated refactors,
+        │         "improvements", or reformatting of adjacent code
+        │   - [ ] No scope creep beyond the issue's Goal (extra features, speculative
+        │         abstractions, config nobody asked for)
+        │   - [ ] No dead code, commented-out blocks, debug prints, or leftover TODOs
+        │   - [ ] Now-unused imports/vars/files the change created are removed
+        │
+        ├─► Step 4: Fits the studio
+        │   - [ ] Matches the project's conventions and existing patterns/style
+        │   - [ ] Core stays target-agnostic — no vendor names/coupling leaked in
+        │         (vendor specifics belong in a profile)
+        │   - [ ] Markdown stays the source of truth; cross-references resolve to
+        │         files that exist
+        │   - [ ] The issue records the work (start / fixes / result) per /dw-implement
+        │
+        ├─► Step 5: Decision
+        │   - PASS: delivers the issue, surgical, fits → ready for a HUMAN to
+        │     review + test, then open a PR (/dw-create-pr <N>) — don't auto-advance
+        │   - REVISE: specific findings — fix on the branch, smallest blast radius
+        │     first (remove leaked scope, fill a gap, tighten); commit
+        │   - HAND BACK: the approach is wrong (wrong design, misread the issue) →
+        │     comment the issue and route back to /dw-implement
+        │
+        └─► Step 6: Report
+            - Per finding: the exact file:line + the smallest fix
+            - A delivery verdict against the issue's "Done When"
+            - The issue link + suggested next step
+
+---
+
+## EXAMPLE
+
+    /dw-review-implement 6
+
+**Agent reads the issue + the branch diff, runs the checks:**
+
+    Delivers the issue (vs "Done When"):
+    ✓ design/wireframes/ holds tokens + components.css/js + components.html
+    ✓ no RUCKUS/R1 strings; brand neutral + configurable on qa-sidebar
+    ✓ demo content target-agnostic
+    ✓ components.html renders standalone in light + dark
+
+    Surgical:
+    ✓ only design/ added + two pointer lines in code/README.md
+    ✓ no dead code / debug leftovers; no unrelated edits
+
+    Fits the studio:
+    ✓ core stays target-agnostic; markdown source of truth intact
+
+**Output:**
+
+    PASS — #6 delivers the issue and stays surgical.
+    A human reviews + tests; open a PR with /dw-create-pr 6 when ready.
+
+(Illustrative — a clean implementation. Real reviews often return REVISE.)
+
+---
+
+## API Notes
+
+- Uses `gh` to read the issue; reads the branch diff with `git` — read-mostly
+- Reviews the local implementation result before it becomes a PR — pairs with
+  /dw-implement the way /dw-review-tasks pairs /dw-tasks
+- This is the substance gate (delivers + surgical), run on the local diff before
+  the PR — there is no separate PR-review command. PR mechanics (linkage, labels)
+  are handled by /dw-create-pr and /dw-merge, and a human reviews + tests the PR
+  before merge.
+- Surgical-change bar mirrors the project's CLAUDE.md (every changed line traces to
+  the request; clean up only your own orphans)
+- When fixing, change only what a finding points to — don't rewrite sound work
+```

--- a/.claude/commands/dev-workflow/dw-review-story.md
+++ b/.claude/commands/dev-workflow/dw-review-story.md
@@ -1,0 +1,96 @@
+# Review a User Story
+
+```
+Review a story for completeness and ensure it stays a goal document, not a spec.
+
+Story ID: {{input}}
+
+## PURPOSE
+
+Quality-gates a story written by `/dw-story` before it becomes work. Checks two
+things: the story is **complete** (every goal section is present and substantive),
+and it is a **goal document, not a spec** (it states the need and the outcome, and
+leaves the *how* to the GitHub issue). Reports findings and revises the story, or
+hands it back to `/dw-story` if the need itself is unclear.
+
+---
+
+## WORKFLOW
+
+    /dw-review-story STORY-001
+        │
+        ├─► Step 1: Read the Story
+        │   - If no story ID provided, list files in docs/stories/ and ask user to pick
+        │   - Read docs/stories/STORY-XXX.md
+        │   - If the story file doesn't exist, report and stop
+        │
+        ├─► Step 2: Completeness Checklist
+        │   - [ ] Title is specific (not a placeholder like "[Title]")
+        │   - [ ] User Story has a real role, action, AND benefit — the "so that"
+        │         is a genuine benefit, not a restatement of the action
+        │   - [ ] The Need explains the problem behind the request (the why), in the
+        │         user's terms — not how it will be built
+        │   - [ ] Success Looks Like lists outcomes someone could actually observe
+        │   - [ ] Open Questions captures what's genuinely unresolved (or says
+        │         "none known" — empty-because-skipped is a finding)
+        │   - [ ] Status has a Created date
+        │
+        ├─► Step 3: Goal-not-Spec Checklist
+        │   - [ ] No implementation detail in the body — no specific files, APIs,
+        │         frameworks, data shapes, or step-by-step "how"
+        │   - [ ] Success Looks Like describes observable user-facing results, not
+        │         implementation steps ("the studio shows the stories", not "parse
+        │         markdown with X and render with Y")
+        │   - [ ] The technical / uncertain "how" lives in Open Questions, deferred
+        │         to the issue — it is not asserted as decided in the body
+        │   - [ ] No acceptance-criteria checklist acting as a build spec
+        │   - [ ] The whole story is decidable by someone who won't implement it
+        │
+        ├─► Step 4: Decision
+        │   - PASS: both checklists clear → report ✓ and suggest /dw-tasks STORY-XXX
+        │   - REVISE: list each finding with the exact line, then fix in place —
+        │     remove leaked spec, fill missing sections, reword success into outcomes
+        │   - HAND BACK: if the *need* itself is unclear or wrong (not just the
+        │     wording), stop and route to /dw-story to re-capture it with the user
+        │
+        └─► Step 5: Report
+            - Print the verdict (PASS / REVISED / HAND BACK) and the findings
+            - Print the path to the story and the suggested next step
+
+---
+
+## EXAMPLE
+
+    /dw-review-story STORY-001
+
+**Agent reads the story, runs both checklists:**
+
+    Completeness:
+    ✓ Title specific — "See the project's stories in the studio"
+    ✓ User Story — role + action + benefit all present
+    ✓ The Need — explains why (studio is the face over the markdown source of truth)
+    ✓ Success Looks Like — observable (studio shows stories, reflects changes)
+    ✓ Open Questions — presentation, status, read strategy all deferred
+    ✓ Status — Created date present
+
+    Goal-not-Spec:
+    ✓ No files/APIs/frameworks asserted in the body
+    ✓ Success is outcome-based, not implementation steps
+    ✓ The "how" sits in Open Questions
+    ✓ No build-spec checklist
+
+**Output:**
+
+    PASS — STORY-001 is complete and stays a goal.
+    docs/stories/STORY-001.md
+    Next: /dw-tasks STORY-001 to open the issue where the "how" gets decided.
+
+---
+
+## API Notes
+
+- Reads only the story file — no GitHub calls
+- The story is a goal; the issue is where the *how* and its history live (see
+  docs/stories/README.md)
+- When revising, change only what a finding points to — don't rewrite a sound story
+```

--- a/.claude/commands/dev-workflow/dw-review-tasks.md
+++ b/.claude/commands/dev-workflow/dw-review-tasks.md
@@ -1,0 +1,97 @@
+# Review the Tasks for a Story
+
+```
+Review the GitHub issues a story was broken into — do they cover the story, and does
+each stay a lean goal rather than a frozen spec?
+
+Story ID: {{input}}
+
+## PURPOSE
+
+Quality-gates the issues created by `/dw-tasks` before implementation starts. Checks
+that **together they cover the story**, and that **each is one small, testable job
+that leaves the *how* to develop on the issue** (not front-loaded as a spec). Fixes
+issue bodies / labels / links in place, or sends the breakdown back to `/dw-tasks` if
+it's wrong.
+
+Fits between `/dw-tasks` (creates issues) and `/dw-implement` (works one):
+
+    dw-story → dw-review-story → dw-tasks → dw-review-tasks → dw-implement → …
+
+---
+
+## WORKFLOW
+
+    /dw-review-tasks STORY-001
+        │
+        ├─► Step 1: Gather
+        │   - If no story ID, list docs/stories/ and ask which to review
+        │   - Read docs/stories/STORY-XXX.md (the goal + "Success Looks Like")
+        │   - List its issues:
+        │     gh issue list --search "[STORY-XXX]" --state all --json number,title,labels,body
+        │   - If no issues exist, report and stop (run /dw-tasks first)
+        │
+        ├─► Step 2: Coverage — the issues vs the story
+        │   - [ ] Every item in the story's "Success Looks Like" is covered by an issue
+        │   - [ ] Nothing essential to delivering the story is missing
+        │   - [ ] No issue goes beyond the story's goal — each traces back to the need
+        │
+        ├─► Step 3: Each issue
+        │   - [ ] One clear job (title + Goal say one thing)
+        │   - [ ] Small enough to finish in a session; independent where it can be
+        │   - [ ] "Done When" is observable — checkable without ambiguity
+        │   - [ ] Body is lean (Context / Goal / Done When); the *how* is NOT frozen in
+        │         — it's left to develop on the issue (research / PoC / comments)
+        │   - [ ] Type + priority labels make sense
+        │
+        ├─► Step 4: Across the set
+        │   - [ ] No two issues substantially duplicate each other
+        │   - [ ] Dependencies/links are sane (no cycles) and the order is buildable
+        │
+        ├─► Step 5: Decision
+        │   - PASS: covers the story + each issue is clean → suggest /dw-implement <first>
+        │   - REVISE: specific fixes — edit the issue body / labels / links in place
+        │     (gh issue edit), or comment what's missing
+        │   - RE-SPLIT: the breakdown itself is wrong (gaps, wrong boundaries, overlap)
+        │     → back to /dw-tasks to re-decompose
+        │
+        └─► Step 6: Report
+            - Per issue: verdict + findings
+            - A coverage verdict against the story
+            - The story path + issue links + suggested next step
+
+---
+
+## EXAMPLE
+
+    /dw-review-tasks STORY-007
+
+**Agent reads the story + its issues, runs the checks:**
+
+    Coverage (vs the story's "Success Looks Like"):
+    ✓ <outcome A>  → #21
+    ✓ <outcome B>  → #22
+    ~ nothing essential missing; no issue exceeds the goal
+
+    Each issue:
+    ✓ #21 one job · Done When observable · lean body (Context / Goal / Done When)
+    ✓ #22 one job · Done When observable · lean body
+
+    Across the set: no overlap; deps are sane and the order is buildable
+
+**Output:**
+
+    PASS — the breakdown covers STORY-007 and each issue stays a goal.
+    Next: /dw-implement 21
+
+(Illustrative — a hypothetical clean breakdown. Real reviews often return REVISE.)
+
+---
+
+## API Notes
+
+- Uses `gh` to read (and, on REVISE, edit) the issues — read-mostly
+- The story is the goal; these issues are the agreed work — keep them lean, the how
+  lives in their comments/history (see docs/stories/README.md)
+- When fixing, change only what a finding points to — don't rewrite a sound breakdown
+```

--- a/.claude/commands/dev-workflow/dw-story.md
+++ b/.claude/commands/dev-workflow/dw-story.md
@@ -1,0 +1,82 @@
+# Create User Story
+
+Create a user story file from user input.
+
+```
+{{input}}
+
+## PURPOSE
+
+Capture the user's **need** as a story file saved to `docs/stories/`. A story is a
+**goal, not a spec** — it states what the user needs and why, and leaves the *how*
+open. Implementation detail (affected files, APIs, design) is worked out later on the
+GitHub issue, not here. See `docs/stories/README.md`.
+
+---
+
+## AGENT WORKFLOW
+
+### Step 1: Determine Story ID
+
+Check `docs/stories/` for existing story files. Generate the next sequential ID:
+- Format: `STORY-XXX` (e.g., STORY-001, STORY-002)
+- If no stories exist, start with STORY-001
+
+### Step 2: Clarify the Need
+
+If the user input is vague, ask questions that sharpen the **need** — not the
+implementation:
+- Who is the user, and what are they trying to achieve?
+- Why does it matter — what's the benefit or the problem behind the request?
+- What would success look like from their point of view?
+
+Do **not** ask about affected files, edge cases, or design here — that gets worked
+out on the issue. If the need is clear enough, proceed directly.
+
+### Step 3: Write Story File
+
+Create `docs/stories/STORY-XXX.md` with this template:
+
+```markdown
+# STORY-XXX: [Title]
+
+## User Story
+
+As a [role],
+I want to [action],
+So that [benefit].
+
+## The Need
+
+[The problem behind the request — what the user is trying to achieve and why, in
+their terms.]
+
+## Success Looks Like
+
+[The outcome that means this is done, described as observable user-facing results —
+not implementation steps.]
+
+## Open Questions
+
+[What still has to be figured out — resolved later on the GitHub issue via research,
+proof of concept, or clarification. The "how" goes here, not above.]
+
+## Status
+
+- Created: [date]
+- Issues: none
+```
+
+### Step 4: Confirm
+
+Show the user the created story and suggest next steps:
+- `/dw-review-story STORY-XXX` to check it's complete and still a goal, not a spec
+- `/dw-tasks STORY-XXX` to open GitHub issue(s) where the *how* gets worked out
+- `/qw-plan` to plan what to test (if QA-related)
+
+---
+
+## OUTPUT
+
+The path to the created story file.
+```

--- a/.claude/commands/dev-workflow/dw-tasks.md
+++ b/.claude/commands/dev-workflow/dw-tasks.md
@@ -1,0 +1,124 @@
+# Break Story into GitHub Issues
+
+```
+Read a user story file and create GitHub issues for each task.
+
+Story ID: {{input}}
+
+## PURPOSE
+
+Reads an existing story file from `docs/stories/STORY-XXX.md` and breaks it into
+implementable GitHub issues. Each issue is linked back to the story via title prefix.
+Updates the story file with created issue numbers.
+
+Fits between `/dw-story` (creates story) and `/dw-implement` (works on an issue):
+
+    dw-story → dw-tasks → dw-implement → dw-create-pr → [human review + test] → dw-merge
+
+---
+
+## WORKFLOW
+
+    /dw-tasks STORY-003
+        │
+        ├─► Step 1: Read the Story
+        │   - If no story ID provided, list files in docs/stories/ and ask user to pick
+        │   - Read docs/stories/STORY-XXX.md
+        │   - Extract: the need and what success looks like (the story holds the
+        │     goal, not a spec — there are no technical notes to copy out)
+        │   - If the story file doesn't exist, report and stop
+        │
+        ├─► Step 2: Break into Tasks
+        │   - Analyze the story and break it into tasks
+        │   - Each task should be:
+        │     • Small — completable in one session
+        │     • Independent — minimal dependencies between tasks
+        │     • Testable — has a clear done condition
+        │   - Detect project type to suggest task breakdown:
+        │     • Check project structure, CLAUDE.md, and existing code patterns
+        │     • Use these to inform sensible task boundaries
+        │   - Present the proposed task list to the user for approval
+        │
+        ├─► Step 3: Check for Duplicates
+        │   - Run: gh issue list --search "[STORY-XXX]" --state all
+        │   - If matching issues exist, report and ask user how to proceed
+        │
+        ├─► Step 4: Create Labels (idempotent)
+        │   - Ensure labels exist (same as /dw-plan):
+        │     • type labels: feature, enhancement, bug, docs
+        │     • priority labels: priority:high, priority:medium, priority:low
+        │     • status labels: status:in-progress, status:needs-review, status:blocked
+        │   - Use: gh label create "<name>" --color "<hex>" --force
+        │
+        ├─► Step 5: Create GitHub Issues
+        │   - One issue per task
+        │   - Title: [STORY-XXX] Task description
+        │   - Body — start lean; the issue grows as the *how* is worked out
+        │     (research, PoC, clarification, fixes) and recorded in comments:
+        │       ## Context
+        │       Part of [STORY-XXX](../docs/stories/STORY-XXX.md)
+        │
+        │       ## Goal
+        │       [what this task achieves, from the story's need]
+        │
+        │       ## Done When
+        │       - [ ] [observable done condition for this task]
+        │   - Labels: type + priority (infer from story content)
+        │   - Link related issues: "Part of STORY-XXX"
+        │
+        ├─► Step 6: Update Story File
+        │   - Update the Status section in docs/stories/STORY-XXX.md:
+        │     ## Status
+        │     - Created: [original date]
+        │     - Issues: #1, #2, #3
+        │
+        └─► Step 7: Report
+            - Show table of created issues:
+              | Issue | Title | Type | Priority |
+            - Suggest implementation order based on dependencies
+            - Suggest: /dw-review-tasks STORY-XXX to gate the breakdown, then
+              /dw-implement <N> to start on the first task
+
+---
+
+## EXAMPLE
+
+    /dw-tasks STORY-003
+
+**Agent reads story, breaks into tasks, creates issues:**
+
+    $ cat docs/stories/STORY-003.md
+    $ gh issue list --search "[STORY-003]" --state all
+    $ gh issue create --title "[STORY-003] Add input validation" \
+        --label "enhancement" --label "priority:high" \
+        --body "## Context\nPart of STORY-003\n\n## Goal\n...\n\n## Done When\n- [ ] ..."
+    $ gh issue create --title "[STORY-003] Add error response formatting" \
+        --label "enhancement" --label "priority:medium" \
+        --body "..."
+
+**Story file updated:**
+
+    ## Status
+    - Created: 2026-04-01
+    - Issues: #15, #16
+
+**Output:**
+
+    | Issue | Title                              | Type        | Priority |
+    |-------|------------------------------------|-------------|----------|
+    | #15   | [STORY-003] Add input validation   | enhancement | high     |
+    | #16   | [STORY-003] Add error formatting   | enhancement | medium   |
+
+    Suggested order: #15 → #16
+    Start: /dw-implement 15
+
+---
+
+## API Notes
+
+- Uses `gh` CLI for issue operations
+- Story files live in `docs/stories/STORY-XXX.md` (created by /dw-story)
+- Issue titles use `[STORY-XXX]` prefix for traceability
+- The story file records the need; the issue is the single source of truth for *how*,
+  growing with research, decisions, and fixes as the work proceeds
+```

--- a/.claude/commands/dev-workflow/dw-test-design.md
+++ b/.claude/commands/dev-workflow/dw-test-design.md
@@ -1,0 +1,188 @@
+# Design Tests for a GitHub Issue
+
+```
+Write tests after implementation, adapted to the project's existing test infrastructure.
+
+Issue number: {{input}}
+
+## PURPOSE
+
+After implementation is complete, this command designs and writes tests that verify
+the changes. It detects what test infrastructure the project uses and generates
+tests in the native format. If no test infrastructure exists, it writes a manual
+test checklist and recommends adopting a test framework.
+
+Fits into the dev-workflow chain after /dw-implement and before /dw-create-pr.
+
+---
+
+## WORKFLOW
+
+    /dw-test-design 47
+        │
+        ├─► Step 1: Understand What Was Implemented
+        │   - Run: gh issue view <N>
+        │   - Read the acceptance criteria and technical notes
+        │   - See what changed vs the repo's default branch — derive it, don't
+        │     hardcode `main` (gh repo view --json defaultBranchRef -q
+        │     .defaultBranchRef.name): git log --oneline <default>..HEAD and
+        │     git diff <default> --stat
+        │   - Identify what needs test coverage
+        │
+        ├─► Step 2: Detect Test Infrastructure
+        │   - Scan the project for existing test tooling:
+        │
+        │     Test Frameworks:
+        │     - cicd/tests/testcases/**/*.yml     → test-framework-template (YAML + dual-judge)
+        │     - tests/ + pytest.ini or conftest.py → pytest
+        │     - __tests__/ or *.test.ts/js         → Jest
+        │     - *.spec.ts/js                       → Jest / Vitest / Mocha
+        │     - *.robot                            → Robot Framework
+        │     - *_test.go                          → Go test
+        │     - **/*Test.java or **/*Spec.java     → JUnit / TestNG
+        │     - tests/ + Cargo.toml                → Rust (cargo test)
+        │
+        │     Test Runners (check even if no test files found):
+        │     - package.json → scripts.test        → npm test
+        │     - Makefile → test target             → make test
+        │     - pyproject.toml → [tool.pytest]     → pytest
+        │     - tox.ini                            → tox
+        │
+        │     CI Pipelines:
+        │     - .github/workflows/                 → GitHub Actions
+        │     - .gitlab-ci.yml                     → GitLab CI
+        │     - Jenkinsfile                        → Jenkins
+        │     - .circleci/                         → CircleCI
+        │     - .travis.yml                        → Travis CI
+        │
+        │   - Record findings: which framework, which runner, which CI
+        │
+        ├─► Step 3: Detect Issue Type (for test scope)
+        │   - Read labels from the GitHub issue:
+        │     - feature, epic, story       → Type A: broad coverage
+        │     - bug, defect                → Type B: regression test targeting the fix
+        │     - enhancement, improvement   → Type C: tests for changed behavior
+        │   - If no label matches, infer from issue title and description
+        │
+        ├─► Step 4: Generate Tests
+        │
+        │   ┌─ IF test infrastructure found:
+        │   │  - Write tests in the project's native format
+        │   │  - Place files where the project's existing tests live
+        │   │  - Follow existing naming conventions and patterns
+        │   │  - Run the project's test command to verify tests pass
+        │   │  - Commit test files to the issue branch
+        │   │
+        │   │  Examples by framework:
+        │   │  - test-framework-template → YAML in cicd/tests/testcases/{suite}/
+        │   │  - pytest   → Python test files in tests/
+        │   │  - Jest     → *.test.ts in __tests__/ or co-located
+        │   │  - Go test  → *_test.go alongside source files
+        │   │  - Robot    → *.robot in tests/ or robot/
+        │   │
+        │   └─ IF no test infrastructure found:
+        │      - Write a manual test checklist in the PR body (Step 5 will use it)
+        │      - Format as markdown checklist:
+        │        ## Test Plan
+        │        - [ ] Step 1: description → expected result
+        │        - [ ] Step 2: description → expected result
+        │      - Add a recommendation note:
+        │        > This project has no automated test infrastructure.
+        │        > Consider adopting [test-framework-template](https://github.com/dogkeeper886/test-framework-template)
+        │        > for YAML-driven CI testing with dual-judge verification.
+        │      - Ask the user: "Want me to create a follow-up issue for CI setup?"
+        │        If yes → create issue labeled "enhancement" + "testing"
+        │
+        ├─► Step 5: Report
+        │   - Summarize what was created:
+        │     - Test framework detected (or "none")
+        │     - CI detected (or "none")
+        │     - Files created/modified
+        │     - Test run result (if applicable)
+        │   - If tests were written, show the test run output
+        │   - Suggest: proceed to /dw-create-pr
+        │
+        └─► Step 5b: On Test Failure
+            - If generated tests fail, investigate:
+              - Is the implementation incomplete?
+              - Is the test expectation wrong?
+            - Fix tests or flag implementation gap to the user
+            - Do not proceed to /dw-create-pr with failing tests
+
+---
+
+## EXAMPLE 1: Project with test-framework-template
+
+    /dw-test-design 47
+
+**Agent detects cicd/tests/testcases/ with YAML files:**
+
+    Detected: test-framework-template (YAML + dual-judge)
+    CI: GitHub Actions (.github/workflows/test-pipeline.yml)
+    Issue #47: enhancement → Type C (changed behavior)
+
+**Generates YAML test case:**
+
+    Created: cicd/tests/testcases/integration/TC-INTEGRATION-002.yml
+    Running: npm test -- --suite integration
+    Result: 2 tests passed (0 failed)
+
+    Next: /dw-create-pr 47
+
+---
+
+## EXAMPLE 2: Project with pytest
+
+    /dw-test-design 12
+
+**Agent detects tests/ + conftest.py:**
+
+    Detected: pytest (tests/conftest.py found)
+    CI: GitHub Actions (.github/workflows/ci.yml)
+    Issue #12: bug → Type B (regression test)
+
+**Generates pytest file:**
+
+    Created: tests/test_issue_12_login_fix.py
+    Running: pytest tests/test_issue_12_login_fix.py -v
+    Result: 3 tests passed
+
+    Next: /dw-create-pr 12
+
+---
+
+## EXAMPLE 3: Project with no test infrastructure
+
+    /dw-test-design 5
+
+**Agent finds no test framework or CI:**
+
+    Detected: no test framework
+    CI: none
+
+    Wrote manual test checklist (will be included in PR body):
+    ## Test Plan
+    - [ ] Navigate to settings page → form loads without errors
+    - [ ] Change display name → saves and shows success message
+    - [ ] Enter invalid email → shows validation error
+
+    > This project has no automated test infrastructure.
+    > Consider adopting [test-framework-template](https://github.com/dogkeeper886/test-framework-template)
+    > for YAML-driven CI testing with dual-judge verification.
+
+    Create follow-up issue for CI setup? [y/n]
+
+    Next: /dw-create-pr 5
+
+---
+
+## API Notes
+
+- Uses `gh` CLI for issue operations
+- Test detection is file-based — scans project root for known patterns
+- Does not install or configure test frameworks — only generates test files
+  for what already exists
+- When multiple test frameworks coexist, prefer the one closest to the
+  changed files
+- Always run tests locally before committing to catch generation errors
+```

--- a/.claude/commands/qa-workflow/qw-bind.md
+++ b/.claude/commands/qa-workflow/qw-bind.md
@@ -1,0 +1,54 @@
+# Bind a Test Doc to its Executable
+
+```
+Link each case in a test doc to the cicd executable that runs it — or port an
+existing executable into a new test-doc scaffold (the revert direction).
+
+Target: a docs/tests/TS-*.md scenario, or a cicd YAML to port.
+
+## PURPOSE
+
+Binding is **audit, not codegen** (per the qa-workflow design): the markdown owns
+*intent* (why / what), the cicd YAML owns *execution* (how it runs). This command
+establishes the link between them; its paired review `/qw-review-bind` checks the
+link still holds.
+
+Fits in the qa-workflow:
+
+    qw-plan → qw-cases → qw-bind → qw-review-bind → qw-run → qw-merge
+    (qw-run = `make up` + the cicd runner — a phase, not a slash command)
+
+---
+
+## WORKFLOW
+
+### A. Forward — bind an existing test doc
+
+    /qw-bind docs/tests/TS-01-stack-lifecycle.md
+        │
+        ├─► For each `### TC-NN:` case, set a `Script:` line to the cicd YAML that
+        │   runs it (e.g. cicd/tests/testcases/integration/TC-INTEGRATION-001.yml).
+        ├─► Keep the case's Steps table aligned 1:1 with the YAML's steps — the
+        │   audit treats a step-count mismatch as `unbound`.
+        └─► Run `/qw-review-bind` to confirm the binding.
+
+### B. Revert — port an executable into a doc scaffold
+
+    /qw-bind cicd/tests/testcases/build/TC-BUILD-001.yml
+        │
+        ├─► Generate a scaffold from the YAML:
+        │     npm --prefix step-store run port-yaml -- <yaml> > docs/tests/TS-NN-<slug>.md
+        │   The scaffold carries the steps and the `Script:` binding; objective,
+        │   expected results, story link, and namespace are TODOs.
+        ├─► Fill the TODOs: `namespace`, `story` (+ `story_hash`), each TC's
+        │   objective and Expected Result column. (The format contract is docs/tests/README.md.)
+        └─► Run `/qw-review-bind` to confirm the binding, then `/qw-cases`-style review.
+
+---
+
+## API Notes
+
+- `port-yaml` is a scaffolder, not a translator — a human/agent fills meaning.
+- `story_hash` = `sha256sum docs/stories/STORY-XXX.md` (the drift anchor, #27).
+- Producer paired with `/qw-review-bind` (the audit).
+```

--- a/.claude/commands/qa-workflow/qw-cases.md
+++ b/.claude/commands/qa-workflow/qw-cases.md
@@ -1,0 +1,55 @@
+# Write the Test Docs
+
+```
+Turn a reviewed test plan into readable test docs in docs/tests/ — reusing vetted
+steps from the store instead of re-inventing them.
+
+Target: the scenarios approved by /qw-review-plan for a STORY-XXX.
+
+## PURPOSE
+
+The authoring producer of the qa-workflow — the test analogue of `dw-implement`.
+Writes each planned scenario as a `docs/tests/TS-*.md` doc in the format contract
+(docs/tests/README.md): front-matter + cases, each case a Steps table of
+Action / Expected Result rows.
+
+Fits in the qa-workflow:
+
+    qw-plan → qw-review-plan → qw-cases → qw-review-cases → qw-bind → qw-run
+    (qw-run = `make up` + the cicd runner — a phase, not a slash command)
+
+---
+
+## WORKFLOW
+
+    /qw-cases STORY-003
+        │
+        ├─► Step 1: One file per scenario
+        │   - Create docs/tests/TS-NN-<slug>.md with front-matter:
+        │       id, title, namespace, story (+ story_hash = sha256 of the story file),
+        │       issue, status: green
+        │   - (Format and field meanings: docs/tests/README.md.)
+        │
+        ├─► Step 2: Write each case (TC) — reuse before re-inventing (dogfood the store)
+        │   - For each step you are about to write, ask the store first:
+        │       make query Q="<the action you mean>"
+        │     If a vetted step comes back close, phrase yours to match it — same
+        │     meaning, same good expected result — instead of coining a new one.
+        │   - Fill the Steps table: each row one Action + its Expected Result.
+        │
+        ├─► Step 3: Index + bind
+        │   - Load the new docs into the store:  npm --prefix step-store run load-tests
+        │   - Bind each case to its executable:  /qw-bind  (then /qw-review-bind)
+        │
+        └─► Step 4: Hand off
+            - Run `/qw-review-cases` to gate the docs.
+
+---
+
+## API Notes
+
+- Reuse is the point of the store: `search_step` (via `make query`) makes a vetted
+  step findable so coverage converges instead of duplicating.
+- `story_hash`: `sha256sum docs/stories/STORY-XXX.md`.
+- Producer paired with `/qw-review-cases`.
+```

--- a/.claude/commands/qa-workflow/qw-drift.md
+++ b/.claude/commands/qa-workflow/qw-drift.md
@@ -1,0 +1,49 @@
+# Check for Test Drift
+
+```
+Surface every test that no longer matches what it verifies — before a stale
+test passes quietly and a green build lies.
+
+Target: every test doc under docs/tests/ (runs in CI and on demand).
+
+## PURPOSE
+
+The freshness gate of the qa-workflow, and a review in its own right (it has no
+paired producer — it checks the whole set). Drift is silent until something looks;
+this looks, deterministically, every run.
+
+Fits in the qa-workflow:
+
+    … → qw-run → [human] → dw-merge   (qw-run = `make up` + the cicd runner, not a slash command)
+                    └──────────────► qw-drift ──► back to qw-cases when stale
+
+---
+
+## WORKFLOW
+
+    /qw-drift
+        │
+        ├─► Run the gate:  npm --prefix step-store run drift
+        │   Two deterministic signals, per case/scenario:
+        │     - STALE   — the linked story's sha256 no longer matches the doc's
+        │                 `story_hash` (the story moved since the test was synced).
+        │     - UNBOUND — the doc and its bound executable diverged (reuses the
+        │                 binding audit).
+        │   Exits non-zero if anything is stale or unbound (so CI fails on drift).
+        │
+        └─► On a finding:
+            - STALE: re-read the test against the changed story. If it still holds,
+              update `story_hash` (`sha256sum docs/stories/STORY-XXX.md`); if not,
+              fix the test via `/qw-cases` → `/qw-review-cases`.
+            - UNBOUND: fix via `/qw-bind` → `/qw-review-bind`.
+
+---
+
+## API Notes
+
+- Hash-first is deterministic and needs no stack; it runs in CI (`.github/workflows/qa-drift.yml`).
+- A semantic, embedding-based signal (softer "drifted in meaning", via the store)
+  is a planned advisory add — hash is the build-failing gate.
+- `status` in a test doc (green | stale | unbound) reflects this gate's verdict.
+- No paired producer — `qw-drift` *is* a review (the qa-workflow pairing rule).
+```

--- a/.claude/commands/qa-workflow/qw-plan.md
+++ b/.claude/commands/qa-workflow/qw-plan.md
@@ -1,0 +1,53 @@
+# Plan What to Test
+
+```
+Derive the scenarios that verify a story (or an on-request target) — the "what
+to test", before any test doc is written.
+
+Target: a STORY-XXX, or an ad-hoc request ("write a test for X").
+
+## PURPOSE
+
+The front of the qa-workflow — the test analogue of reading a story before
+implementing. It produces a short, reviewable list of **scenarios** (each a TS-to-be)
+that together cover the need, so `qw-cases` has a scoped plan to write against.
+
+Fits in the qa-workflow:
+
+    qw-plan → qw-review-plan → qw-cases → qw-review-cases → qw-bind → qw-run
+    (qw-run = `make up` + the cicd runner — a phase, not a slash command)
+
+---
+
+## WORKFLOW
+
+    /qw-plan STORY-003
+        │
+        ├─► Step 1: Read the need
+        │   - If a STORY-XXX: read docs/stories/STORY-XXX.md (the need + "Success Looks Like").
+        │   - If an on-request target: restate what behaviour is to be verified.
+        │
+        ├─► Step 2: Check what already exists (dogfood the store)
+        │   - Search the step-store for steps/cases already covering this:
+        │       make query Q="<the behaviour>"
+        │     so the plan reuses vetted coverage instead of duplicating it.
+        │   - List the docs/tests/ scenarios already linked to this story:
+        │       grep -l 'story: STORY-XXX' docs/tests/
+        │
+        ├─► Step 3: Propose scenarios
+        │   - Break the need into scenarios (TS-to-be), each:
+        │     • one coherent slice of behaviour, • independently runnable,
+        │     • mappable to one or more cicd executables.
+        │   - For each, name the cases (TC-to-be) it will hold, at a sentence each.
+        │
+        └─► Step 4: Hand off
+            - Present the scenario list for `/qw-review-plan`, then `/qw-cases`.
+
+---
+
+## API Notes
+
+- A scenario here is a *plan item*, not yet a file — `qw-cases` writes the doc.
+- The story is the goal; keep the plan to coverage, not step detail.
+- Producer paired with `/qw-review-plan`.
+```

--- a/.claude/commands/qa-workflow/qw-review-bind.md
+++ b/.claude/commands/qa-workflow/qw-review-bind.md
@@ -1,0 +1,52 @@
+# Review a Test Doc ↔ Script Binding
+
+```
+Audit that each test doc and its bound executable still agree — flag any case
+whose doc and script have diverged as `unbound`.
+
+Target: the docs/tests/ scenarios (all, or one named file).
+
+## PURPOSE
+
+The paired review for `/qw-bind`. Binding is audit-not-codegen, so something has to
+*check* that the markdown and the YAML haven't drifted apart. This runs the
+deterministic audit and adds a human/agent pass for meaning.
+
+Fits in the qa-workflow:
+
+    qw-plan → qw-cases → qw-bind → qw-review-bind → qw-run → qw-merge
+    (qw-run = `make up` + the cicd runner — a phase, not a slash command)
+
+---
+
+## WORKFLOW
+
+    /qw-review-bind
+        │
+        ├─► Step 1: Run the deterministic audit
+        │     npm --prefix step-store run audit-bind
+        │   For each case it checks:
+        │     - the `Script:` path resolves to a file, and
+        │     - the doc's step count matches the YAML's step count.
+        │   A failure prints `UNBOUND` with the reason; the command exits non-zero
+        │   (so CI and the drift gate, #27, can gate on it).
+        │
+        ├─► Step 2: Read the meaning the audit can't
+        │   For each `bound` case, skim that the doc's Actions/Expected Results
+        │   still describe what the YAML actually does — structure can match while
+        │   meaning has drifted. Flag any semantic mismatch.
+        │
+        └─► Step 3: Decision
+            - PASS: every case `bound` (audit exits 0) and meaning holds.
+            - REVISE: for each `UNBOUND` (or semantic mismatch), fix the doc's
+              Steps/`Script:` or the binding — smallest change first — then re-run.
+
+---
+
+## API Notes
+
+- The audit (`audit-bind`) is structural + deterministic; it is the runnable check
+  CI and `/qw-drift` reuse. Semantic agreement is the reviewer's job.
+- `unbound` is one of the test doc's `status` values (docs/tests/README.md).
+- Review paired with the producer `/qw-bind`.
+```

--- a/.claude/commands/qa-workflow/qw-review-cases.md
+++ b/.claude/commands/qa-workflow/qw-review-cases.md
@@ -1,0 +1,48 @@
+# Review the Test Docs
+
+```
+Check each test doc does one clear job, has observable steps, and traces back to
+its story — before it is bound and run.
+
+Target: the docs/tests/TS-*.md docs written by /qw-cases for a STORY-XXX.
+
+## PURPOSE
+
+The paired review for `/qw-cases`. The test-doc analogue of `dw-review-implement`:
+gates the written docs for quality and traceability.
+
+Fits in the qa-workflow:
+
+    qw-plan → qw-review-plan → qw-cases → qw-review-cases → qw-bind → qw-run
+    (qw-run = `make up` + the cicd runner — a phase, not a slash command)
+
+---
+
+## WORKFLOW
+
+    /qw-review-cases STORY-003
+        │
+        ├─► Step 1: Each doc
+        │   - [ ] One scenario, one job; cases are coherent slices of it.
+        │   - [ ] Front-matter complete and resolvable: story file exists,
+        │         story_hash matches it, namespace set, status present.
+        │   - [ ] Each step's Expected Result is observable — checkable, not vague.
+        │   - [ ] Conforms to the format contract (docs/tests/README.md).
+        │
+        ├─► Step 2: Traceability
+        │   - [ ] story → doc → (script, via qw-bind) resolves both ways.
+        │   - [ ] No duplicate of an existing scenario for the same story.
+        │
+        └─► Step 3: Decision
+            - PASS: docs do their job and trace back → proceed to `/qw-bind` (if not
+              yet bound), then run it (`make up` + the cicd runner).
+            - REVISE: fix the named doc — smallest change first — and re-check.
+
+---
+
+## API Notes
+
+- This reviews the *doc* (intent); `/qw-review-bind` reviews the doc↔script binding.
+- Published-deliverable phrasing/typography is out of scope here.
+- Review paired with the producer `/qw-cases`.
+```

--- a/.claude/commands/qa-workflow/qw-review-plan.md
+++ b/.claude/commands/qa-workflow/qw-review-plan.md
@@ -1,0 +1,46 @@
+# Review the Test Plan
+
+```
+Check the proposed scenarios cover the story — and stay coverage, not a frozen
+step-by-step spec.
+
+Target: the scenario list from /qw-plan for a STORY-XXX — as proposed in the
+conversation, or as already realized in docs/tests/ when reviewing after the fact.
+
+## PURPOSE
+
+The paired review for `/qw-plan`. Gates the plan before `qw-cases` writes any docs,
+so coverage gaps are caught cheaply.
+
+Fits in the qa-workflow:
+
+    qw-plan → qw-review-plan → qw-cases → qw-review-cases → qw-bind → qw-run
+    (qw-run = `make up` + the cicd runner — a phase, not a slash command)
+
+---
+
+## WORKFLOW
+
+    /qw-review-plan STORY-003
+        │
+        ├─► Step 1: Coverage vs the story
+        │   - [ ] Every item in the story's "Success Looks Like" maps to a scenario.
+        │   - [ ] Nothing essential to verifying the story is missing.
+        │   - [ ] No scenario goes beyond the story's need.
+        │
+        ├─► Step 2: Each scenario
+        │   - [ ] One coherent slice; independently runnable.
+        │   - [ ] Maps to at least one cicd executable (or names the gap to author).
+        │   - [ ] No duplication of a scenario already in docs/tests/ (grep the story link).
+        │
+        └─► Step 3: Decision
+            - PASS: covers the story → proceed to `/qw-cases`.
+            - REVISE: name the missing or excess scenario; back to `/qw-plan`.
+
+---
+
+## API Notes
+
+- Coverage gate only — step detail is `qw-cases`/`qw-review-cases`'s job.
+- Review paired with the producer `/qw-plan`.
+```

--- a/.claude/rules/workflow-patterns.md
+++ b/.claude/rules/workflow-patterns.md
@@ -42,18 +42,22 @@ Both patterns use `test-run.yml` as the single reusable job.
 
 **Dual triggers:** Each workflow supports both `workflow_dispatch` (manual, with dropdowns) and `workflow_call` (callable from pipeline). This lets you run features independently or as part of the full CI.
 
-**Judge mode dropdown:** Each workflow offers `simple` (fast, no LLM) or `dual` (simple + LLM) judge modes via input.
+**Judge mode dropdown:** Each workflow offers `simple` (default — fast, deterministic, no model) or `dual` (simple + the opt-in LLM judge). The workflow sets `LLM_JUDGE_MODE` from this input; the runner is simple-only unless it reads `dual`.
 
 ## Environment Variables
 
-Configure LLM judge via GitHub repository variables (`Settings > Variables > Actions`):
+The LLM judge reaches its model through the Anthropic SDK, so any Anthropic-compatible
+endpoint (the hosted API or a local one) is a matter of configuration. Set these via
+GitHub repository variables/secrets (`Settings > Variables/Secrets > Actions`):
 
 | Variable | Purpose | Example |
 |----------|---------|---------|
-| `LLM_JUDGE_URL` | Ollama endpoint | `http://localhost:11434` |
-| `LLM_JUDGE_MODEL` | Model for judging | `llama3:8b` |
+| `LLM_JUDGE_MODE` | `simple` (default) or `dual` (opt in the LLM judge) | `dual` |
+| `LLM_JUDGE_MODEL` | Model for judging | `claude-haiku-4-5-20251001` |
+| `LLM_JUDGE_URL` | Base URL of an Anthropic-compatible endpoint (unset → hosted Anthropic API) | `http://localhost:11434` |
+| `ANTHROPIC_API_KEY` | API key for the hosted API (secret; a placeholder works for a local endpoint that ignores auth) | `sk-ant-...` |
 
-**Separate judge instance:** If your project tests an Ollama instance (e.g., on port 11434), run the LLM judge on a different port (e.g., 11435) to avoid GPU memory contention. Set `LLM_JUDGE_URL=http://localhost:11435` in your repo variables.
+**Local endpoint:** To judge against a local Anthropic-compatible model server, point `LLM_JUDGE_URL` at it. Keeping the judge on a separate endpoint from any model your project itself tests avoids resource contention.
 
 ## Legacy Workflows
 

--- a/.claude/skills/ci-run/SKILL.md
+++ b/.claude/skills/ci-run/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: ci-run
-description: Execute test cases with dual-judge evaluation
+description: Execute test cases with the simple judge by default, or opt in the LLM judge
 user-invocable: true
 ---
 
 # Run Test Cases
 
-Execute test cases and evaluate results with the dual-judge system.
+Execute test cases and evaluate results. The simple (deterministic) judge is the
+default verdict; the LLM judge is an opt-in second opinion (`LLM_JUDGE_MODE=dual`).
 
 ```
 $ARGUMENTS
@@ -85,17 +86,19 @@ Instead of agent-based execution, use the built-in CLI:
 
 ```bash
 cd cicd/tests
-npm test                        # All tests with LLM judge
-npm test -- --no-llm            # Without LLM judge
+npm test                        # All tests (simple judge — fast, no model)
 npm test -- --suite integration # Specific suite
 npm test -- --id TC-INT-001     # Specific test
 npm test -- --tag auth          # Tests tagged 'auth'
 npm test -- --dry-run           # Preview only
+LLM_JUDGE_MODE=dual npm test    # Opt in the LLM judge (env, not a flag)
 ```
 
 **Environment variables for CI:**
-- `LLM_JUDGE_URL` — Ollama endpoint (default: `http://localhost:11434`)
-- `LLM_JUDGE_MODEL` — Model for judging (default: `llama3:8b`)
+- `LLM_JUDGE_MODE` — `simple` (default) or `dual` (opt in the LLM judge)
+- `LLM_JUDGE_MODEL` — Model for judging (default: `claude-haiku-4-5-20251001`)
+- `LLM_JUDGE_URL` — Base URL of an Anthropic-compatible endpoint (unset → hosted Anthropic API)
+- `ANTHROPIC_API_KEY` — API key for the hosted API
 
 ---
 

--- a/.claude/skills/install/SKILL.md
+++ b/.claude/skills/install/SKILL.md
@@ -42,8 +42,9 @@ Examine the current working directory:
 Prompt the user with detected defaults:
 
 - **Project name** — from package.json or ask
-- **Ollama URL** — default: `http://localhost:11434`
-- **Ollama model** — default: `llama3:8b`
+- **Judge mode** — default: `simple` (deterministic, no model); `dual` opts in the LLM judge
+- **LLM judge model** — default: `claude-haiku-4-5-20251001` (used in dual mode)
+- **LLM judge endpoint** — optional Anthropic-compatible base URL (unset → hosted Anthropic API)
 - **Include MCP client?** — auto-yes if MCP SDK detected
 - **Include Docker log collector?** — auto-yes if docker-compose found
 - **Install Claude skills?** — recommend yes
@@ -72,8 +73,8 @@ Prompt the user with detected defaults:
 3. **Adapt config.ts** — replace placeholder values with user's answers:
    - `projectName: 'my-project'` -> actual project name
    - `sessionPrefix: 'test-session'` -> `'{name}-session'`
-   - `llm.defaultUrl` -> user's Ollama URL
-   - `llm.defaultModel` -> user's model
+   - `llm.model` -> user's judge model (default `claude-haiku-4-5-20251001`)
+   - `llm.baseUrl` -> user's endpoint, if any (else leave unset for the hosted Anthropic API)
 
 4. **Create `.gitignore`** in `cicd/results/`:
    ```
@@ -97,7 +98,7 @@ Show the user:
 - Next steps:
   - Write test cases: `cicd/tests/testcases/<suite>/*.yml`
   - Customize error patterns: `cicd/tests/src/config.ts`
-  - Run tests: `cd cicd/tests && npm test -- --no-llm`
+  - Run tests: `cd cicd/tests && npm test`
   - Generate test cases: `/ci-testcase`
 
 ---

--- a/.claude/skills/reviewing-artifacts/SKILL.md
+++ b/.claude/skills/reviewing-artifacts/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: reviewing-artifacts
+description: |
+  Reviews any workflow artifact — the commands, skills, and project docs that are the
+  tooling (READMEs, stories, CLAUDE.md, and the like) — against five goal questions:
+  one clear job, complete, a goal not a frozen spec, fits the studio, right for its
+  reader. Also runs a producer→review pairing coverage pass that flags any producer
+  shipped without a paired review. It judges whether an artifact does its job; how a
+  human-read doc (the README, docs/ prose) looks and reads goes to the typography +
+  phrasing review. Floor, not ceiling.
+---
+
+# reviewing-artifacts
+
+One reviewer for every workflow artifact. It does not score against a fixed checklist
+or a published standard — it asks a few questions about whether the artifact does its
+job and fits this project, and trusts your judgment for the rest.
+
+**The questions are a floor, not a ceiling.** If something hurts the artifact and
+isn't listed below, flag it anyway.
+
+**Scope.** Review whatever artifact you're handed, *by kind* — commands, skills,
+READMEs, stories, CLAUDE.md, and anything like them. Don't tie this skill to a fixed
+inventory of the current commands and skills; new ones appear and old ones change. The
+fine-grained **look and words** of a human-read doc — the README, the prose in `docs/` —
+go to `reviewing-typography` (the look) + `reviewing-phrasing` (the words); this skill
+judges whether the artifact does its job (Q5 still asks whether a doc serves its reader).
+
+## The five questions
+
+Ask these of any artifact. The artifact's type shifts which ones bite hardest.
+
+1. **One clear job.** Can you say what this file is for in a sentence? Does everything
+   in it serve that one job? Flag sprawl (steps that wander off) and heavy overlap with
+   another artifact (could it merge, or go away?).
+2. **Complete.** Does it deliver that job end to end — no missing steps, placeholder
+   text, or dead instructions that produce nothing? A reader/agent should be able to act.
+3. **Goal, not frozen spec — and no hardcoding.** Does it state intent and leave room
+   where room belongs, instead of freezing a "how" that will drift? Flag stale paths or
+   filenames, magic values that should be derived, rigid step-by-step where a principle
+   would do, and references to tools or layouts that have moved.
+4. **Fits the studio.** Does it match the conventions this project actually uses —
+   markdown as the source of truth, plus the tools and layout the repo relies on now —
+   rather than a stack it has moved past? Flag coupling to a tool or layout the project
+   has genuinely retired or relocated; an integration the studio still uses, or a
+   deliberate adapter, is not a violation. Cross-references resolve to files that exist.
+5. **Right for its reader.** Agent-facing (commands, skills): unambiguous instructions
+   the agent can follow. Human-facing (README, story): reads like a person wrote it for
+   a person — clear, concrete, scannable.
+
+Where each type leans:
+
+| Artifact | Leans on |
+|----------|----------|
+| Command / skill | Q3 (no hardcoding), Q5 (agent can follow it) |
+| README / user doc | Q5 (reads for a human), Q1 (one clear job) |
+| Story | Q3 (goal, not spec) — this is what `dw-review-story` checks at the story stage |
+| CLAUDE.md | Q2/Q4 (matches the repo as it actually is — no orphaned references) |
+
+## Producer→review pairing (coverage pass)
+
+A standing rule (CLAUDE.md → "Review pairing"): every **producer** has a **paired
+review**. When the scope is the whole workflow — or any change that adds/edits a
+producer — run this coverage pass on top of the five questions.
+
+It is a **method, not a fixed list** — derive the producers and reviews from whatever
+units exist now; don't hardcode an inventory that will drift.
+
+1. **List the producers.** A producer is any unit that *creates, syncs, publishes, or
+   drafts a deliverable* — by name (`create-`, `sync-`, `publish-`, `draft-`, `init-`)
+   or by what it does (a producing gerund skill — a name like `planning-…`, `drafting-…`).
+2. **List the reviews.** Any unit whose job is to *check a result* — `*-review`,
+   `*-verify`, the `reviewing-*` skills, a typography/format audit.
+3. **Match each producer to the review that covers its output.** A pairing is real only
+   if some review actually inspects what that producer makes.
+4. **Flag the gaps.** Name every producer with **no** review covering its output — that
+   is a pairing violation. Note the missing review and where it would live.
+5. **Mark the exempt.** A producer that yields no outward deliverable to review —
+   internal scaffolding, a visual folded into an already-reviewed doc, an authoring
+   input, tooling logs — is **exempt**, not a gap. List it as exempt and say why.
+
+Report pairings as a small table and list the unpaired producers as findings:
+
+```
+Producer → Review
+<producer>           → <review>            ✓
+<producer>           → (none)              ✗  needs: <proposed review + home>
+<producer>           → (exempt)            —  <why it has no outward deliverable>
+```
+
+## Steps
+
+1. **Scope.** A single file, a folder, or "the files I just changed." Find where the
+   artifacts actually live in *this* repo — don't assume a fixed layout.
+2. **Read** the target(s).
+3. **Ask the five questions** of each. Checklists are a floor — note anything else that
+   weakens the artifact.
+4. **Pairing coverage pass** (when reviewing the workflow or a producer change) — run
+   the section above and report unpaired producers.
+5. **Report** (below).
+6. **Fix (if asked).** Smallest blast radius first: remove leaked hardcoding, fill gaps,
+   tighten wording. Structural changes — merging, splitting, or removing an artifact —
+   need explicit confirmation. Never delete an artifact without approval; flag it for
+   removal instead.
+
+## Report
+
+Per artifact, a short verdict and the specific findings — no numeric score.
+
+```
+<artifact path> — PASS | REVISE | CUT
+
+- [Q#] <finding, with line reference> → <smallest fix>
+```
+
+- **PASS** — does its job, fits the studio, nothing leaked.
+- **REVISE** — specific, fixable findings (gaps, hardcoding, drift, readability).
+- **CUT** — duplicates another artifact or does nothing useful; propose removal (with approval).
+
+End with the path(s) reviewed and the suggested next step.

--- a/.claude/skills/reviewing-phrasing/SKILL.md
+++ b/.claude/skills/reviewing-phrasing/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: reviewing-phrasing
+description: |
+  Reviews the words of a human-read document — the README, the prose in docs/, or any
+  text written for a person rather than an agent — for whether the phrasing fits its
+  reader: leads with the point, stays brief, carries the right tone, and says the true
+  complete thing and only that. The words half of the human-read doc review
+  (reviewing-typography handles the look). Use when such a doc is written or updated and
+  is about to reach a reader. Judgment over checklist; floor, not ceiling.
+---
+
+# reviewing-phrasing
+
+One reviewer for the **words** of any document written for a person. Its partner
+`reviewing-typography` judges how a doc *looks*; this judges how it *reads*. Together
+they are the human-read doc review.
+
+This skill's job is **human-read** text — the README, the prose inside `docs/`, and any
+text aimed at a person. The **agent-read** workflow tooling — commands, skills, rules,
+CLAUDE.md, stories — is **not** this skill's job; whether those do their job goes to
+`reviewing-artifacts`.
+
+## Why this is a judgment skill, not a checklist
+
+Good phrasing can't be frozen into a rule. The sentence that's right in a quickstart is
+wrong in a design rationale; a line that lands for an engineer loses a newcomer. There is
+no fixed order and no score — read the doc as its **actual reader** would and decide what
+helps and what hurts. Use common sense.
+
+## What to weigh
+
+These are **lenses, not steps** — they interact, and which bites hardest depends on the
+doc in hand. Weigh them together, and flag anything that weakens the writing even if it
+isn't named here.
+
+- **Reader.** Who actually reads this, and what do they already know? The phrasing meets
+  them there — no unexplained jargon for a newcomer, no over-explaining to a peer.
+- **Lead with the point.** The reader should hit what matters first, not after a runway of
+  setup. Context that arrives before the point reads as not knowing the priority — or as
+  hiding something. Front-load the conclusion; let the detail follow for those who want it.
+- **Brevity.** Less is more. Every word earns its place; cut filler, hedging, and the
+  second sentence that restates the first. A reader skimming a long file rewards a doc that
+  respects their time.
+- **Content.** Does it say the true, complete thing the reader needs — and only that? No
+  vague filler, nothing burying the one fact that matters, no gap that forces the reader to
+  go ask the obvious. Brevity is not omission: precise, not contextless.
+- **Tone.** Does it fit the relationship and the moment? A quickstart, a caveat, and a
+  rationale each carry a different register.
+- **Purpose.** The doc exists to move one outcome — get someone set up, understood, or
+  unblocked. Do the words drive *that*, or wander off it?
+
+## The test
+
+When unsure whether a passage lands, read it as the reader would — or show it to someone
+who isn't in your head. Where they get lost or lose interest is where the words are
+redundant, buried, or missing a hook. That spot is the finding.
+
+## Steps
+
+1. **Scope.** Which doc(s), and who the reader is. If the reader isn't clear from the doc
+   or its context, ask before reviewing.
+2. **Read it as that reader would** — once, straight through, for whether it lands.
+3. **Weigh the lenses** above by judgment; note anything else that hurts the phrasing.
+4. **Report** (below).
+5. **Fix (if asked).** The smallest change that fixes the phrasing — keep the author's
+   voice, don't rewrite what already works, don't pad. A clean doc gets said so, with no
+   invented findings.
+
+## Report
+
+Per doc, a short verdict and specific findings — no numeric score.
+
+```
+<doc> — PASS | REVISE
+
+- <what hurts the phrasing, quoted> → <smallest fix>
+```
+
+- **PASS** — fits its reader, leads with the point, says the right thing.
+- **REVISE** — specific, fixable findings (buried point, padding, wrong register, missing fact).
+
+End with what was reviewed and the suggested next step.

--- a/.claude/skills/reviewing-typography/SKILL.md
+++ b/.claude/skills/reviewing-typography/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: reviewing-typography
+description: |
+  Reviews how a human-read document looks — the README, the prose and tables in docs/, or
+  any markdown written for a person — for visual hierarchy, Gestalt proximity, restraint,
+  and walls of text, so a reader can find the point at a glance. The look half of the
+  human-read doc review (reviewing-phrasing handles the words). Use when such a doc is
+  written or restructured. Judgment over checklist; floor, not ceiling.
+---
+
+# reviewing-typography
+
+One reviewer for how a human-read document **looks**. Its partner `reviewing-phrasing`
+judges how a doc *reads*; this judges how it *scans*. Together they are the human-read doc
+review.
+
+This skill's job is **human-read** markdown — the README, the prose, tables, and lists in
+`docs/`, and any doc aimed at a person. The **agent-read** workflow tooling — commands,
+skills, rules, CLAUDE.md, stories — is **not** this skill's job; whether those do their job
+goes to `reviewing-artifacts`.
+
+A markdown doc has no fonts to set, but it has the same levers UI typography uses, and the
+same principles decide whether it works: **heading levels** are size/weight, **blank lines
+and grouping** are spacing, **bold/italic** are weight, and **paragraph and list length**
+decide whether the page reads as structure or as soup.
+
+## Why this is a judgment skill, not a checklist
+
+The right structure depends on the content's actual shape, which no rule can predict. A
+metadata line reads fine until real prose lands under it and the two fuse. One bold label
+anchors the eye; ten bold labels compete and the hierarchy collapses. A 4-item list reads
+cleanly; a 17-item list reads as a paragraph. **Look at the doc and decide** — there is no
+rule set that survives contact with arbitrary content.
+
+## What to weigh
+
+These are **lenses, not steps**. Weigh them together; flag anything that weakens the look
+even if it isn't named here.
+
+- **Hierarchy.** Can the eye find the point of focus? A doc with no heading structure reads
+  as one undifferentiated blob — the reader has no idea what they're looking at. The title
+  and section heads should be visibly heavier than the body; each level distinct from the
+  next.
+- **Proximity (grouping).** Spacing groups or separates. Related lines sit together; a real
+  break — a blank line, a heading, a rule — sits between things that aren't one group.
+  Where ideas cross layers (metadata → prose, intro → first section) they need the loosest
+  separation, or they fuse.
+- **Restraint.** You need very few levels. A handful of heading depths plus weight is enough
+  to build any doc; piling on nested headings, or bolding every other phrase, *destroys*
+  hierarchy rather than adding it.
+- **Emphasis by de-emphasis.** To make something stand out, tone the rest down. If every
+  paragraph opens with a bold phrase, none of them anchor anything. Emphasis is a budget —
+  spend it on the few things the reader should land on.
+- **Wall of text.** A long undifferentiated paragraph, or an 800-word stretch with no
+  heading break, reads as soup. Break at the natural boundary; promote a `**Label:**`
+  followed by a long list into a real heading.
+- **Structure for the true shape, then for focus.** Use heading levels for the doc's real
+  hierarchy — but also use common sense about what the reader should focus on and let that
+  stand out. Don't structure for structure's sake; structure for whether the reader can
+  *use* the doc.
+
+## The test
+
+Squint at the rendered doc — or scan it without reading any word. The visible weight order
+(title → headings → emphasis → body) should be obvious at a glance. If you can't tell the
+levels apart unfocused, the hierarchy isn't doing its job. When unsure, show it to someone
+and watch where their eye snags or stalls; that spot is the finding.
+
+## Steps
+
+1. **Scope.** Which doc(s). If unclear, ask before reviewing.
+2. **Scan it as a reader would** — unfocused first (does the shape read?), then through.
+3. **Weigh the lenses** above by judgment; note anything else that hurts the look.
+4. **Report** (below).
+5. **Fix (if asked).** The smallest change that fixes the look — a heading break, a blank
+   line, removing bold from the labels that aren't anchors. Don't restructure what already
+   reads well; don't invent findings on a clean doc (it trains everyone to ignore the real
+   ones).
+
+## Report
+
+Per doc, a short verdict and specific findings — no numeric score.
+
+```
+<doc> — PASS | REVISE
+
+- <what hurts the look, with the location> → <smallest fix>
+```
+
+- **PASS** — the eye finds the point; hierarchy and grouping hold.
+- **REVISE** — specific, fixable findings (no hierarchy, fused groups, bold inflation, wall of text).
+
+End with what was reviewed and the suggested next step.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
   #   name: "Test: Auth"
   #   needs: build
   #   uses: ./.github/workflows/test-run.yml
+  #   secrets: inherit          # passes ANTHROPIC_API_KEY through for dual mode
   #   with:
   #     tag: auth
   #     judge_mode: ${{ inputs.judge_mode }}
@@ -39,6 +40,7 @@ jobs:
     name: "Test: All"
     needs: build
     uses: ./.github/workflows/test-run.yml
+    secrets: inherit            # passes ANTHROPIC_API_KEY through for dual mode
     with:
       judge_mode: ${{ inputs.judge_mode }}
       judge_model: ${{ inputs.judge_model }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
       judge_model:
         description: "LLM model for judging (if dual mode)"
         required: false
-        default: "llama3:8b"
+        default: "claude-haiku-4-5-20251001"
         type: string
 
 jobs:

--- a/.github/workflows/test-feature-example.yml
+++ b/.github/workflows/test-feature-example.yml
@@ -30,6 +30,7 @@ on:
 jobs:
   test:
     uses: ./.github/workflows/test-run.yml
+    secrets: inherit                    # passes ANTHROPIC_API_KEY through for dual mode
     with:
       tag: "example"                    # <-- Change this to your feature tag
       judge_mode: ${{ inputs.judge_mode }}

--- a/.github/workflows/test-pipeline.yml
+++ b/.github/workflows/test-pipeline.yml
@@ -7,7 +7,7 @@ on:
       judge_mode:
         description: "Test judge mode"
         required: false
-        default: "dual"
+        default: "simple"
         type: choice
         options:
           - "simple"
@@ -15,7 +15,7 @@ on:
       judge_model:
         description: "LLM model for judging (if dual mode)"
         required: false
-        default: "llama3:8b"
+        default: "claude-haiku-4-5-20251001"
         type: string
 
 jobs:

--- a/.github/workflows/test-pipeline.yml
+++ b/.github/workflows/test-pipeline.yml
@@ -22,6 +22,7 @@ jobs:
   build:
     name: Build Tests
     uses: ./.github/workflows/test-suite.yml
+    secrets: inherit
     with:
       suite: build
       judge_mode: ${{ inputs.judge_mode }}
@@ -31,6 +32,7 @@ jobs:
     name: Integration Tests
     needs: build
     uses: ./.github/workflows/test-suite.yml
+    secrets: inherit
     with:
       suite: integration
       judge_mode: ${{ inputs.judge_mode }}
@@ -40,6 +42,7 @@ jobs:
     name: E2E Tests
     needs: integration
     uses: ./.github/workflows/test-suite.yml
+    secrets: inherit
     with:
       suite: e2e
       judge_mode: ${{ inputs.judge_mode }}

--- a/.github/workflows/test-run.yml
+++ b/.github/workflows/test-run.yml
@@ -15,14 +15,14 @@ on:
         required: false
         type: string
       judge_mode:
-        description: "Judge mode (simple = no LLM, dual = simple + LLM)"
+        description: "Judge mode (simple = deterministic only, dual = simple + LLM judge)"
         required: false
         default: "simple"
         type: string
       judge_model:
-        description: "LLM model for judging"
+        description: "LLM model for judging (dual mode)"
         required: false
-        default: "llama3:8b"
+        default: "claude-haiku-4-5-20251001"
         type: string
     outputs:
       result:
@@ -53,14 +53,16 @@ jobs:
 
       - name: Run tests
         id: run-tests
+        env:
+          # Simple by default; dual opts in the LLM judge. URL/model/key configure
+          # the Anthropic SDK — leave LLM_JUDGE_URL unset for the hosted Anthropic API,
+          # or set it (repo variable) to any Anthropic-compatible endpoint.
+          LLM_JUDGE_MODE: ${{ inputs.judge_mode }}
+          LLM_JUDGE_MODEL: ${{ vars.LLM_JUDGE_MODEL || inputs.judge_model }}
+          LLM_JUDGE_URL: ${{ vars.LLM_JUDGE_URL }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           cd cicd/tests
-
-          # Set LLM judge env vars from repo variables (fall back to defaults)
-          export LLM_JUDGE_URL="${{ vars.LLM_JUDGE_URL }}"
-          export LLM_JUDGE_MODEL="${{ vars.LLM_JUDGE_MODEL }}"
-          [ -z "$LLM_JUDGE_URL" ] && export LLM_JUDGE_URL="http://localhost:11434"
-          [ -z "$LLM_JUDGE_MODEL" ] && export LLM_JUDGE_MODEL="${{ inputs.judge_model }}"
 
           # Build filter flags
           FILTER_FLAGS=""
@@ -70,18 +72,10 @@ jobs:
             FILTER_FLAGS="--suite ${{ inputs.suite }}"
           fi
 
-          # Build judge flags
-          JUDGE_FLAGS=""
-          if [ "${{ inputs.judge_mode }}" = "simple" ]; then
-            JUDGE_FLAGS="--no-llm"
-          else
-            JUDGE_FLAGS="--judge-model ${{ inputs.judge_model }}"
-          fi
-
           echo "Filter: $FILTER_FLAGS"
-          echo "Judge: $JUDGE_FLAGS"
+          echo "Judge mode: $LLM_JUDGE_MODE"
 
-          npx tsx src/cli.ts run $FILTER_FLAGS $JUDGE_FLAGS --format json > /tmp/test-results.json || true
+          npx tsx src/cli.ts run $FILTER_FLAGS --format json > /tmp/test-results.json || true
 
           echo "--- Results ---"
           cat /tmp/test-results.json

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -16,7 +16,7 @@ on:
       judge_mode:
         description: "Test judge mode"
         required: false
-        default: "dual"
+        default: "simple"
         type: choice
         options:
           - "simple"
@@ -24,7 +24,7 @@ on:
       judge_model:
         description: "LLM model for judging (if dual mode)"
         required: false
-        default: "llama3:8b"
+        default: "claude-haiku-4-5-20251001"
         type: string
   workflow_call:
     inputs:
@@ -35,12 +35,12 @@ on:
       judge_mode:
         description: "Test judge mode (simple, dual)"
         required: false
-        default: "dual"
+        default: "simple"
         type: string
       judge_model:
         description: "LLM model for judging"
         required: false
-        default: "llama3:8b"
+        default: "claude-haiku-4-5-20251001"
         type: string
     outputs:
       result:
@@ -68,16 +68,14 @@ jobs:
 
       - name: Run tests
         id: run-tests
+        env:
+          # Simple by default; dual opts in the LLM judge via the Anthropic SDK.
+          LLM_JUDGE_MODE: ${{ inputs.judge_mode }}
+          LLM_JUDGE_MODEL: ${{ vars.LLM_JUDGE_MODEL || inputs.judge_model }}
+          LLM_JUDGE_URL: ${{ vars.LLM_JUDGE_URL }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           cd cicd/tests
-
-          # Build judge flags based on input
-          JUDGE_FLAGS=""
-          if [ "${{ inputs.judge_mode }}" = "simple" ]; then
-            JUDGE_FLAGS="--no-llm"
-          else
-            JUDGE_FLAGS="--judge-model ${{ inputs.judge_model || 'llama3:8b' }}"
-          fi
 
           # Build suite flag
           SUITE_FLAG=""
@@ -86,11 +84,10 @@ jobs:
           fi
 
           echo "Suite: ${{ inputs.suite }}"
-          echo "Judge mode: ${{ inputs.judge_mode || 'dual' }}"
-          echo "Judge flags: $JUDGE_FLAGS"
+          echo "Judge mode: $LLM_JUDGE_MODE"
 
           # Run tests with JSON output
-          npx tsx src/cli.ts run $SUITE_FLAG $JUDGE_FLAGS --format json > /tmp/test-results.json || true
+          npx tsx src/cli.ts run $SUITE_FLAG --format json > /tmp/test-results.json || true
 
           echo "--- JSON Results ---"
           cat /tmp/test-results.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,115 +1,106 @@
 # CLAUDE.md
 
-Guidance for Claude Code when working on the test-framework-template.
+Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.
 
-## Project Overview
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
 
-Reusable, YAML-driven CI test framework with dual-judge verification (Simple + LLM). Part of the ai-qa-workflow ecosystem (Phase 5: Automate).
+## 1. Think Before Coding
 
-## Installation
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
 
-Agent-driven: run `/install` and follow the prompts.
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
 
-Manual alternative:
-```bash
-make install TARGET=/path/to/project NAME=project-name
-cd /path/to/project/cicd/tests && npm install
-# Edit config.ts for your project
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
 ```
 
-## Core Commands
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
 
-```bash
-cd cicd/tests
-npm run build                      # TypeScript compile
-npm test                           # Run all tests with LLM judge
-npm test -- --no-llm               # Run without LLM (faster)
-npm test -- --suite build          # Run specific suite
-npm test -- --id TC-001            # Run specific test
-npm test -- --tag auth             # Run tests tagged 'auth'
-npm test -- --dry-run              # Preview without executing
-npm run list                       # List available tests
-npm run list -- --tag auth         # List tests by tag
-```
+## 5. Dev-workflow discipline
 
-## Project Structure
+Substantial work flows through a pipeline; each step is a gate that stops for a
+human decision (commands suggest the next, they never auto-run it):
 
 ```
-cicd/tests/
-├── src/
-│   ├── cli.ts              # CLI entry point (Commander)
-│   ├── config.ts           # Project configuration — customize per project
-│   ├── types.ts            # Core interfaces (TestCase, TestStep, etc.)
-│   ├── loader.ts           # YAML parser with dependency resolution
-│   ├── executor.ts         # Test execution with variable capture
-│   ├── mcp-client.ts       # MCP tool client (optional)
-│   ├── log-collector.ts    # Docker log capture (optional)
-│   ├── judge/              # Simple + LLM judges
-│   └── reporter/           # Console + JSON reporters
-├── testcases/
-│   ├── build/              # TC-BUILD-*.yml
-│   ├── integration/        # TC-INT-*.yml
-│   └── e2e/                # TC-E2E-*.yml
-└── package.json
-
-.claude/
-├── skills/                 # /ci-testcase, /ci-run, /add-tool, /install, /review-docs-privacy
-└── rules/                  # test-yaml-format.md, workflow-patterns.md
+dw-story → dw-tasks → dw-review-tasks → dw-implement
+        → dw-review-implement → dw-create-pr → dw-merge
 ```
 
-## Test Case YAML
+Two review gates are external skills this repo does not own — invoke them by hand:
+- `code-review` (bundled): adversarial diff review. Run after `dw-implement`,
+  alongside `dw-review-implement`. Earns its cost on logic/risk; skip for pure docs.
+- `/review` (builtin): PR overview. Run after `dw-create-pr`, before `dw-merge`.
 
-See `.claude/rules/test-yaml-format.md` for full schema, variable capture syntax, and suite guidelines.
+Don't wire these into the `dw-*` commands — they may not exist in every install,
+and a command that references a missing skill is a dangling pointer.
 
-Key fields: `id`, `name`, `suite`, `steps`, `tags` (optional), `criteria`, `goal`, `dependencies`.
+**Right-size it.** A typo or a one-line doc change does not need the full chain —
+use judgment, branch + PR + merge is enough. The three review passes overlap:
+`dw-review-implement` is the always-on substance gate, `code-review` is for real
+logic or risk, `/review` is the PR summary. Running all three on a trivial diff is
+ritual, not rigor.
 
-## Dual-Judge System
+## 6. Artifact & doc review discipline
 
-Both judges must pass for a test to pass:
-- **Simple Judge**: Exit codes, expectPatterns, rejectPatterns, ERROR_PATTERNS
-- **LLM Judge**: Semantic analysis via Ollama against `criteria` and `goal`
+Match the reviewer to **who reads** the file you changed:
 
-Use `--no-llm` to skip LLM judging when Ollama is unavailable.
+- **Human-read docs** (README, `docs/` prose): run `reviewing-phrasing` (the words)
+  + `reviewing-typography` (the look) — the human-read doc review.
+- **Agent-read tooling** (commands, skills, CLAUDE.md, rules): run
+  `reviewing-artifacts` (does it do its job — one job, complete, goal-not-spec,
+  fits the studio, right for its reader).
 
-## Configuration
+These are skills this repo owns. Like the dev-workflow gates, they stop for a human
+and never auto-run — invoke them by hand.
 
-Edit `config.ts` per project:
-- `projectName` — used in LLM prompts
-- `SUITES` — extend with custom suite names (e.g., `runtime`, `inference`)
-- `ERROR_PATTERNS` / `ERROR_EXCLUSIONS` — project-specific error detection
-- `mcp.serverCommand` — MCP server startup command
+**Right-size it.** A typo or a one-line tweak does not need a review pass — use
+judgment. Reach for these when a change is substantial enough that the look, the
+wording, or the artifact's fitness actually matters.
 
-**Environment variables** (for CI, override without editing source):
-- `LLM_JUDGE_URL` — Ollama endpoint (default: `http://localhost:11434`)
-- `LLM_JUDGE_MODEL` — Model for judging (default: `llama3:8b`)
+---
 
-**Separate judge instance:** If testing an Ollama instance, run the judge on a different port to avoid GPU contention.
-
-## MCP Client (Optional)
-
-For MCP server projects, `mcp-client.ts` spawns the server and calls tools:
-```bash
-npx tsx cicd/tests/src/mcp-client.ts <tool_name> '<json_args>'
-```
-Configure via `MCP_SERVER_COMMAND` env var or `config.ts` → `mcp.serverCommand`.
-
-## CI Workflows
-
-See `.claude/rules/workflow-patterns.md` for per-feature and suite-based workflow patterns.
-
-Template includes: `build.yml`, `test-run.yml`, `test-feature-example.yml`, `ci.yml` (recommended) and legacy `test-pipeline.yml`, `test-suite.yml`.
-
-## Development Guidelines
-
-- Keep everything configurable via `config.ts` — never hardcode project-specific values
-- Template files are installed via agent-driven flow (`/install`) or Makefile fallback
-- Follow existing TypeScript patterns (strict types, async/await)
-- No hardcoded IPs, infrastructure IDs, or private repo references
-
-## Skills
-
-- `/ci-testcase` — generate YAML test cases from requirements
-- `/ci-run` — execute tests with guided output
-- `/add-tool` — add new MCP tools following standard patterns
-- `/install` — install framework into a project
-- `/review-docs-privacy` — review for security and quality
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dual-Judge Test Framework Template
 
-A reusable, YAML-driven test framework with dual-judge verification (Simple + LLM) for CI/CD pipelines.
+A reusable, YAML-driven test framework for CI/CD pipelines. Fast and deterministic by default (the simple judge), with an opt-in LLM judge as a second opinion — reached through the Anthropic SDK, so any Anthropic-compatible endpoint (hosted or local) is just configuration.
 
 ## Project Goal
 
@@ -29,13 +29,13 @@ The framework is built around three core principles:
 |------------|---------|
 | **TypeScript** | Strict type safety and modern async/await patterns |
 | **YAML** | Declarative test case definitions |
-| **Ollama** | Local LLM integration for semantic judging |
+| **Anthropic SDK** | Reaches any Anthropic-compatible endpoint (hosted or local) for the opt-in semantic judge |
 | **Docker Compose** | Log collection with marker-based extraction |
 | **GitHub Actions** | CI/CD pipeline orchestration |
 
 ### Notable Features
 
-- **Dual-Judge System**: Both simple (fast) and LLM (semantic) judges must pass
+- **Dual-Judge System**: Fast deterministic judge by default; opt in the semantic LLM judge (`LLM_JUDGE_MODE=dual`) and both must pass
 - **YAML-Driven Tests**: Tests defined as configuration, not code
 - **Tag-Based Filtering**: Filter tests by feature tag via `--tag` for per-feature CI workflows
 - **Variable Capture**: Extract values from step output and pass to later steps via `{{variable}}`
@@ -150,7 +150,7 @@ Traditional tests only check exit codes. A process can exit with code 0 but prod
 
 The LLM judge reads the criteria from YAML and evaluates whether the actual output semantically satisfies the requirements—catching failures that pattern matching alone would miss.
 
-Use `--no-llm` to skip LLM judging for faster CI feedback when Ollama is unavailable.
+**The LLM judge is opt-in.** By default a run uses the simple judge only: fast, deterministic, and model-free. Set `LLM_JUDGE_MODE=dual` to also run the LLM judge — then both must pass (the verification above). A configured-but-unreachable endpoint degrades cleanly, falling back to the simple judge with a notice.
 
 ## Quick Start
 
@@ -196,10 +196,12 @@ export const SUITES: string[] = ['build', 'integration', 'e2e'];
 export const CONFIG = {
   projectName: 'your-project',
   
-  // LLM Judge settings (overridable via env vars)
+  // LLM Judge — opt-in second opinion (default verdict is the simple judge)
   llm: {
-    defaultUrl: process.env.LLM_JUDGE_URL || 'http://localhost:11434',
-    defaultModel: process.env.LLM_JUDGE_MODEL || 'llama3:8b',
+    mode: process.env.LLM_JUDGE_MODE || 'simple',          // 'simple' | 'dual'
+    baseUrl: process.env.LLM_JUDGE_URL || undefined,        // unset → hosted Anthropic API
+    apiKey: process.env.ANTHROPIC_API_KEY || 'local',
+    model: process.env.LLM_JUDGE_MODEL || 'claude-haiku-4-5-20251001',
     timeout: 300000,
     stdoutLimit: 1000,
     stderrLimit: 500,
@@ -217,22 +219,23 @@ export const ERROR_PATTERNS: RegExp[] = [
 
 ### Environment Variables
 
-For CI environments, override LLM judge settings without editing source:
+For CI environments, configure the judge without editing source:
 
 | Variable | Purpose | Default |
 |----------|---------|---------|
-| `LLM_JUDGE_URL` | Ollama endpoint | `http://localhost:11434` |
-| `LLM_JUDGE_MODEL` | Model for judging | `llama3:8b` |
+| `LLM_JUDGE_MODE` | `simple` (deterministic only) or `dual` (opt in the LLM judge) | `simple` |
+| `LLM_JUDGE_MODEL` | Model for judging | `claude-haiku-4-5-20251001` |
+| `LLM_JUDGE_URL` | Base URL of an Anthropic-compatible endpoint (unset → hosted Anthropic API) | unset |
+| `ANTHROPIC_API_KEY` | API key for the hosted API (a placeholder works for a local endpoint that ignores auth) | `local` |
 
-**Tip:** If your project tests an Ollama instance (port 11434), run the LLM judge on a separate port (e.g., 11435) to avoid GPU memory contention.
+**Tip:** To judge against a local Anthropic-compatible model server, set `LLM_JUDGE_URL` to its address. Keeping the judge on a separate endpoint from any model your project itself tests avoids resource contention.
 
 ## Running Tests
 
 ```bash
 cd your-project/cicd/tests
 
-npm test                    # Run all tests with LLM judge
-npm test -- --no-llm        # Run without LLM (faster)
+npm test                    # Run all tests (simple judge — fast, no model)
 npm test -- --suite build   # Run specific suite
 npm test -- --id TC-001     # Run specific test
 npm test -- --tag auth      # Run tests tagged 'auth'
@@ -240,8 +243,9 @@ npm test -- --dry-run       # Preview what would run
 npm run list                # List available tests
 npm run list -- --tag auth  # List tests by tag
 
-# Override Ollama settings via CLI
-npm test -- --judge-url http://host:11434 --judge-model gemma3:12b
+# Opt in the LLM judge (env-configured, not a flag)
+LLM_JUDGE_MODE=dual npm test
+LLM_JUDGE_MODE=dual LLM_JUDGE_URL=http://host:11434 LLM_JUDGE_MODEL=gemma3:12b npm test
 ```
 
 ## CI Workflow Patterns
@@ -289,7 +293,7 @@ jobs:
 3. Change the `tag` value
 4. Add as a job in `ci.yml`
 
-Configure `LLM_JUDGE_URL` and `LLM_JUDGE_MODEL` as GitHub repository variables (`Settings > Variables > Actions`).
+Configure the judge with GitHub repository variables and secrets (`Settings > Variables/Secrets > Actions`): `LLM_JUDGE_MODE`, `LLM_JUDGE_MODEL`, `LLM_JUDGE_URL`, and the `ANTHROPIC_API_KEY` secret.
 
 ## MCP Testing
 

--- a/cicd/tests/package-lock.json
+++ b/cicd/tests/package-lock.json
@@ -8,7 +8,7 @@
       "name": "test-framework",
       "version": "1.0.0",
       "dependencies": {
-        "axios": "^1.7.2",
+        "@anthropic-ai/sdk": "^0.102.0",
         "chalk": "^5.3.0",
         "commander": "^12.1.0",
         "glob": "^10.3.10",
@@ -22,6 +22,44 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.102.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.102.0.tgz",
+      "integrity": "sha512-cThh3KcPW3lzkFyTz1cjyhJvOVw45NkLMoowO2ZJ/76CBz44ADUon+NsjEc/PypAkARs72Xu8qxTnx6PAOTQUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -493,6 +531,12 @@
         "node": ">=14"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/js-yaml": {
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
@@ -540,23 +584,6 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
-    "node_modules/axios": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
-      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -570,19 +597,6 @@
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/chalk": {
@@ -615,18 +629,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commander": {
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
@@ -650,29 +652,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -684,51 +663,6 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "license": "MIT"
-    },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/esbuild": {
       "version": "0.27.2",
@@ -772,25 +706,11 @@
         "@esbuild/win32-x64": "0.27.2"
       }
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
@@ -808,22 +728,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -837,52 +741,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/get-tsconfig": {
@@ -916,57 +774,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/is-fullwidth-code-point": {
@@ -1011,41 +818,24 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
-    },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/minimatch": {
       "version": "9.0.5",
@@ -1102,12 +892,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
-    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -1149,6 +933,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
       }
     },
     "node_modules/string-width": {
@@ -1246,6 +1040,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/tsx": {
       "version": "4.21.0",

--- a/cicd/tests/package.json
+++ b/cicd/tests/package.json
@@ -14,7 +14,7 @@
     "dev": "tsx src/cli.ts"
   },
   "dependencies": {
-    "axios": "^1.7.2",
+    "@anthropic-ai/sdk": "^0.102.0",
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
     "glob": "^10.3.10",

--- a/cicd/tests/src/cli.ts
+++ b/cicd/tests/src/cli.ts
@@ -34,9 +34,6 @@ program
   .option('-i, --id <id>', 'Run only the test with this ID')
   .option('-t, --tag <tag>', 'Run only tests with this tag')
   .option('--dry-run', 'Show what would run without executing', false)
-  .option('--no-llm', 'Skip LLM judging (simple judge only)')
-  .option('--judge-url <url>', 'Ollama URL for LLM judge', CONFIG.llm.defaultUrl)
-  .option('--judge-model <model>', 'Model to use for LLM judging', CONFIG.llm.defaultModel)
   .option('-o, --output-dir <dir>', 'Output directory for results')
   .option('-f, --format <format>', 'Output format (console, json)', 'console')
   .action(async (options) => {
@@ -62,9 +59,7 @@ program
       testId: options.id,
       tag: options.tag,
       dryRun: options.dryRun,
-      noLlm: !options.llm,
-      judgeUrl: options.judgeUrl,
-      judgeModel: options.judgeModel,
+      dualMode: CONFIG.llm.mode === 'dual',
       outputDir,
       outputFormat: options.format as RunConfig['outputFormat'],
       workingDir: projectRoot,
@@ -75,7 +70,7 @@ program
     process.stderr.write(`[CONFIG] Docker compose: ${dockerDir}\n`);
     process.stderr.write(`[CONFIG] Testcases: ${testcasesDir}\n`);
     process.stderr.write(`[CONFIG] Output: ${outputDir}\n`);
-    process.stderr.write(`[CONFIG] LLM Judge: ${config.noLlm ? 'disabled' : config.judgeUrl}\n`);
+    process.stderr.write(`[CONFIG] LLM Judge: ${config.dualMode ? `dual (${CONFIG.llm.baseUrl || 'Anthropic API'}, ${CONFIG.llm.model})` : 'simple only'}\n`);
 
     // Load test cases
     const loader = new TestLoader(testcasesDir);
@@ -144,19 +139,18 @@ program
 
     let llmJudgments = simpleJudgments.map((j) => ({
       ...j,
-      reason: config.noLlm ? 'LLM judge disabled' : j.reason,
+      reason: config.dualMode ? j.reason : 'LLM judge disabled (simple mode)',
     }));
 
-    if (!config.noLlm) {
+    if (config.dualMode) {
       process.stderr.write('[JUDGE] Running LLM judge...\n');
-      const llmJudge = new LLMJudge(config.judgeUrl, config.judgeModel);
+      const llmJudge = new LLMJudge();
 
       const available = await llmJudge.isAvailable();
       if (available) {
         llmJudgments = await llmJudge.judgeResults(results);
-        await llmJudge.unloadModel();
       } else {
-        process.stderr.write('[WARN] LLM judge not available, using simple judge results\n');
+        process.stderr.write('[WARN] LLM judge endpoint unreachable, falling back to simple judge results\n');
       }
     }
 

--- a/cicd/tests/src/config.ts
+++ b/cicd/tests/src/config.ts
@@ -25,10 +25,18 @@ export const CONFIG = {
   defaultTimeout: 60000,
   defaultStepTimeout: 30000,
   
-  // LLM Judge defaults
+  // LLM Judge — an opt-in second opinion. The default verdict is the simple
+  // (deterministic, model-free) judge; set LLM_JUDGE_MODE=dual to also run this.
   llm: {
-    defaultUrl: process.env.LLM_JUDGE_URL || 'http://localhost:11434',
-    defaultModel: process.env.LLM_JUDGE_MODEL || 'llama3:8b',
+    // 'simple' (default) = deterministic checks only. 'dual' = also run the LLM judge.
+    mode: process.env.LLM_JUDGE_MODE || 'simple',
+    // Optional base URL for any Anthropic-compatible endpoint (hosted or local).
+    // Unset → the Anthropic SDK's default endpoint.
+    baseUrl: process.env.LLM_JUDGE_URL || undefined,
+    // Real key for hosted Anthropic; a placeholder is fine for a local endpoint
+    // that ignores auth.
+    apiKey: process.env.ANTHROPIC_API_KEY || 'local',
+    model: process.env.LLM_JUDGE_MODEL || 'claude-haiku-4-5-20251001',
     timeout: 300000,
     stdoutLimit: 1000,
     stderrLimit: 500,

--- a/cicd/tests/src/judge/llm-judge.ts
+++ b/cicd/tests/src/judge/llm-judge.ts
@@ -1,36 +1,50 @@
 /**
- * LLM Judge - Semantic analysis of test results using Ollama.
+ * LLM Judge - Semantic analysis of test results via the Anthropic SDK.
  *
  * Uses a language model to evaluate test execution logs against criteria.
  * Catches silent failures that exit code checking misses.
  *
- * Judges one test at a time with structured JSON prompts and Ollama JSON mode
- * for reliable parsing. Includes observability logging for debugging CI failures.
+ * Reaches its model through the standard Anthropic client, so any
+ * Anthropic-compatible endpoint (hosted or a local one) is a matter of
+ * configuration (LLM_JUDGE_URL / LLM_JUDGE_MODEL / ANTHROPIC_API_KEY), not a
+ * code change. Judges one test at a time with a structured JSON prompt.
  */
 
-import axios from 'axios';
+import Anthropic from '@anthropic-ai/sdk';
 import { TestResult, Judgment } from '../types.js';
 import { CONFIG } from '../config.js';
 
 export class LLMJudge {
-  private ollamaUrl: string;
+  private client: Anthropic;
   private model: string;
 
   constructor(
-    ollamaUrl: string = CONFIG.llm.defaultUrl,
-    model: string = CONFIG.llm.defaultModel
+    baseUrl: string | undefined = CONFIG.llm.baseUrl,
+    model: string = CONFIG.llm.model,
+    apiKey: string = CONFIG.llm.apiKey
   ) {
-    this.ollamaUrl = ollamaUrl;
+    this.client = new Anthropic({
+      apiKey,
+      baseURL: baseUrl,
+      timeout: CONFIG.llm.timeout,
+    });
     this.model = model;
   }
 
+  /**
+   * Probe the configured endpoint. Returns false on any connection/auth error
+   * so the caller can skip cleanly and fall back to the simple judge.
+   */
   async isAvailable(): Promise<boolean> {
     try {
-      const response = await axios.get(`${this.ollamaUrl}/api/tags`, {
-        timeout: 5000,
+      await this.client.messages.create({
+        model: this.model,
+        max_tokens: 1,
+        messages: [{ role: 'user', content: 'ping' }],
       });
-      return response.status === 200;
-    } catch {
+      return true;
+    } catch (error) {
+      process.stderr.write(`  [LLM] Endpoint not reachable: ${error}\n`);
       return false;
     }
   }
@@ -83,7 +97,7 @@ export class LLMJudge {
       steps,
       container_logs: this.truncate(r.logs, CONFIG.llm.logsLimit),
       respond: {
-        format: 'Respond with a single JSON object',
+        format: 'Respond with a single JSON object and nothing else',
         fields: {
           testId: r.testCase.id,
           pass: 'true if test meets all criteria, false otherwise',
@@ -105,33 +119,34 @@ export class LLMJudge {
   }
 
   /**
+   * Extract the first JSON object from a model response, tolerating prose or
+   * markdown fences around it.
+   */
+  private extractJson(text: string): string | null {
+    const start = text.indexOf('{');
+    const end = text.lastIndexOf('}');
+    if (start === -1 || end === -1 || end < start) return null;
+    return text.substring(start, end + 1);
+  }
+
+  /**
    * Judge a single test result.
    */
   private async judgeOne(result: TestResult): Promise<Judgment> {
     const prompt = this.buildPrompt(result);
     const testId = result.testCase.id;
 
-    const response = await axios.post(
-      `${this.ollamaUrl}/api/generate`,
-      {
-        model: this.model,
-        prompt,
-        stream: false,
-        format: 'json',
-        options: {
-          temperature: 0.1,
-          num_predict: 1024,
-        },
-      },
-      {
-        timeout: CONFIG.llm.timeout,
-      }
-    );
+    const response = await this.client.messages.create({
+      model: this.model,
+      max_tokens: 1024,
+      temperature: 0.1,
+      messages: [{ role: 'user', content: prompt }],
+    });
 
-    const responseText = response.data.response;
-    const promptTokens = response.data.prompt_eval_count ?? '?';
-    const responseTokens = response.data.eval_count ?? '?';
-    process.stderr.write(`  [LLM] Tokens for ${testId}: prompt=${promptTokens}, response=${responseTokens}\n`);
+    const textBlock = response.content.find((b) => b.type === 'text');
+    const responseText = textBlock && textBlock.type === 'text' ? textBlock.text : '';
+
+    process.stderr.write(`  [LLM] Tokens for ${testId}: prompt=${response.usage.input_tokens}, response=${response.usage.output_tokens}\n`);
 
     // Handle empty response
     if (!responseText) {
@@ -145,8 +160,18 @@ export class LLMJudge {
 
     process.stderr.write(`  [LLM] Raw response for ${testId} (${responseText.length} chars): ${responseText.substring(0, 500)}\n`);
 
+    const json = this.extractJson(responseText);
+    if (!json) {
+      process.stderr.write(`  [LLM] WARNING: No JSON object in response for ${testId}\n`);
+      return {
+        testId,
+        pass: false,
+        reason: `No JSON object in LLM response: ${responseText.substring(0, 200)}`,
+      };
+    }
+
     try {
-      const judgment = JSON.parse(responseText) as Judgment;
+      const judgment = JSON.parse(json) as Judgment;
 
       // Validate testId matches
       if (judgment.testId !== testId) {
@@ -212,24 +237,5 @@ export class LLMJudge {
     }
 
     return allJudgments;
-  }
-
-  async unloadModel(): Promise<void> {
-    try {
-      process.stderr.write(`  [LLM] Unloading judge model ${this.model}...\n`);
-      await axios.post(
-        `${this.ollamaUrl}/api/generate`,
-        {
-          model: this.model,
-          keep_alive: 0,
-        },
-        {
-          timeout: 30000,
-        }
-      );
-      process.stderr.write(`  [LLM] Judge model unloaded.\n`);
-    } catch {
-      process.stderr.write(`  [LLM] Warning: Failed to unload judge model\n`);
-    }
   }
 }

--- a/cicd/tests/src/types.ts
+++ b/cicd/tests/src/types.ts
@@ -223,12 +223,8 @@ export interface RunConfig {
   tag?: string;
   /** Show what would run without executing */
   dryRun: boolean;
-  /** Skip LLM judging (simple judge only) */
-  noLlm: boolean;
-  /** URL of the LLM judge Ollama instance */
-  judgeUrl: string;
-  /** Model to use for LLM judging */
-  judgeModel: string;
+  /** Also run the LLM judge (opt-in via LLM_JUDGE_MODE=dual); default is simple-only */
+  dualMode: boolean;
   /** Output directory for results */
   outputDir: string;
   /** Output format */
@@ -244,6 +240,6 @@ export interface RunConfig {
  */
 export const DEFAULT_CONFIG: Partial<RunConfig> = {
   dryRun: false,
-  noLlm: false,
+  dualMode: false,
   outputFormat: 'console',
 };

--- a/docs/skill-inventory.md
+++ b/docs/skill-inventory.md
@@ -1,0 +1,31 @@
+# Skill & Command Inventory
+
+The record behind STORY-001's question *"which skills does the template actually
+use, and which should be retired?"* Inventory first, then retire — and the
+inventory found nothing unused, so nothing was retired.
+
+## What's here and who uses it
+
+| Artifact | Role | Referenced by |
+|---|---|---|
+| `install` skill | Installs the framework into a project | the entry point; ships the three skills below |
+| `ci-testcase` skill | Generates YAML test cases | shipped into projects by `install`; `/ci-testcase` |
+| `ci-run` skill | Runs test cases (simple judge default, LLM judge opt-in) | shipped into projects by `install` |
+| `add-tool` skill | Adds MCP tools | shipped into projects by `install` |
+| `review-docs-privacy` skill | Security + doc-quality review | README skills table |
+| `reviewing-artifacts` skill | Agent-read artifact review | `CLAUDE.md` §6 |
+| `reviewing-phrasing` skill | Human-read doc — the words | `CLAUDE.md` §6 |
+| `reviewing-typography` skill | Human-read doc — the look | `CLAUDE.md` §6 |
+| `dev-workflow/dw-*` commands | Story → tasks → implement → PR → merge pipeline | `CLAUDE.md` §5 |
+| `qa-workflow/qw-*` commands | Test-doc planning, authoring, binding, drift | `dw-story`, `qw-drift` |
+
+## Decision
+
+**Retire nothing.** Every skill and command is referenced — the test-framework
+skills (`install`, `ci-run`, `ci-testcase`, `add-tool`) are shipped by `install`;
+the rest are maintainer tooling wired into this repo's `CLAUDE.md` §5/§6. None is
+orphaned, so there is no unused skill to retire.
+
+Scoping the template down to only the shipped test-framework skills would be a
+deliberate change of intent, not an unused-code cleanup — and it would contradict
+the `CLAUDE.md` discipline this repo runs on. Out of scope here.

--- a/docs/stories/STORY-001.md
+++ b/docs/stories/STORY-001.md
@@ -1,0 +1,65 @@
+# STORY-001: Bring the template's testing experience back in line with its tooling
+
+## User Story
+
+As a maintainer of the test-framework-template,
+I want the template's test runner and its Claude tooling to describe the same, modernized experience — fast by default, with an optional LLM judge that talks to its model the standard way,
+So that someone installing the template gets a coherent setup instead of commands and docs that promise a workflow the code doesn't actually run.
+
+## The Need
+
+This template was adopted downstream by `ai-qa-step-graph`, which then matured the
+experience. Two things drifted apart here:
+
+- **The tooling has already been copied in** — the `dev-workflow` and `qa-workflow`
+  commands under `.claude/commands/`, the `reviewing-artifacts` / `reviewing-phrasing`
+  / `reviewing-typography` skills, and the `CLAUDE.md` discipline. They sit in the repo
+  untracked and unreconciled.
+- **The test runner still behaves the old way.** It leans on an LLM judge by default,
+  and that judge reaches its model through a hand-rolled HTTP call to Ollama rather than
+  the standard client every other Anthropic-compatible tool uses.
+
+So the copied-in commands and docs talk about a testing flow the runner doesn't deliver,
+and the template carries skills it may no longer use. A person installing this template
+can't trust that what the tooling says is what the code does. The experience should be:
+fast and deterministic out of the box, with the LLM judge there when you want a second
+opinion, reached through the standard client so any Anthropic-compatible endpoint
+(including a local one) is just configuration — and with the tooling trimmed to what the
+template actually uses.
+
+## Success Looks Like
+
+- Running the tests with no extra flags is fast and needs no model — the deterministic
+  checks are the default verdict.
+- The LLM judge is still available as a second opinion when asked for; the dual-judge
+  idea is kept, not dropped.
+- When the LLM judge does run, it reaches its model through the standard Anthropic client,
+  so pointing it at any Anthropic-compatible endpoint (a hosted one or a local Ollama) is
+  a matter of configuration, not a code change — and it degrades cleanly when no endpoint
+  is configured.
+- The copied-in commands, reviewing skills, and `CLAUDE.md` are reconciled into the repo
+  and describe this same experience — nothing references a workflow the runner no longer
+  performs.
+- The template ships only the skills it actually uses; ones that no longer earn their
+  place are retired.
+- The README and rules read true against the runner's actual behavior.
+
+## Open Questions
+
+- Which skills count as "unused" and should be retired, versus kept? (Needs an
+  inventory of what the template actually exercises before anything is removed.)
+- Should the default-vs-opt-in choice be a flag, an environment setting, or both — and
+  what is the least surprising default name for the dual mode?
+- How should a configured-but-unreachable model endpoint behave — skip with a notice, or
+  fail the run? (Leaning skip, to keep the default path model-free.)
+- Does retiring/reconciling tooling ripple into the CI workflows that currently let a
+  caller pick a judge mode?
+- The downstream `step-store` semantic-reuse pattern (vector store + its own service) is
+  explicitly **out of scope** here — is it worth a separate future story, or not for a
+  template?
+
+## Status
+
+- Created: 2026-06-08
+- Tasks: #15, #16, #17
+- Tests: none


### PR DESCRIPTION
## Summary

Brings the template's test runner and its Claude tooling into one coherent, modernized experience.

- **#15 — Modernize the LLM judge.** Replace the hand-rolled axios/Ollama HTTP calls with the standard `@anthropic-ai/sdk` client; any Anthropic-compatible endpoint (hosted or local) is reached by config (`LLM_JUDGE_URL`/`LLM_JUDGE_MODEL`/`ANTHROPIC_API_KEY`). Flip the default to **simple-only** (deterministic, no model); the LLM judge is opt-in via env **`LLM_JUDGE_MODE=dual`**. The dual-judge idea is kept; a configured-but-unreachable endpoint degrades cleanly to the simple judge. Removed the now-dead `--no-llm`/`--judge-*` flags.
- **#16 — Reconcile copied-in tooling.** Track `.claude/commands/` (dev/qa-workflow), the reviewing-* skills, `CLAUDE.md`, and `docs/`. Make `/ci-run` and the install skill read true. Inventory (`docs/skill-inventory.md`): every skill/command is referenced — nothing is orphaned, so nothing is retired.
- **#17 — Make README, rules, and CI read true.** Simple-by-default framing with the LLM judge as an opt-in second opinion via the Anthropic SDK; the 6 CI workflows select judge mode through `LLM_JUDGE_MODE` (no flags), default to simple, and propagate `ANTHROPIC_API_KEY` via `secrets: inherit`.

Fixes #15
Fixes #16
Fixes #17

Part of STORY-001

## Test plan

- [x] `npm run build` passes (tsc clean)
- [x] No-flag run reports "LLM Judge: simple only" and needs no model (verified via `--dry-run`)
- [x] Dual mode with an unreachable endpoint warns and falls back to the simple judge (verified live)
- [x] Independent code review: TypeScript correctness clean, docs-vs-code clean; one CI secret-propagation gap found and fixed
- [ ] **Known caveat:** the example test fixtures don't go green in this bare repo — they run host commands at the repo root (no root `package.json`, no Docker). Host-dependent and pre-existing; the simple-judge and executor code is unchanged.

Generated with [Claude Code](https://claude.com/claude-code)