### PR TITLE
Port the dev-workflow plan-stage

### DIFF
--- a/.claude/commands/dev-workflow/dw-implement.md
+++ b/.claude/commands/dev-workflow/dw-implement.md
@@ -22,6 +22,9 @@ and prepares for PR creation when done.
         │   - Read acceptance criteria, technical notes, dependencies
         │   - Check labels — type and priority should already be set
         │   - Check for linked/blocking issues
+        │   - If the issue body links a plan ("Part of #<plan>"), read that plan
+        │     issue — its Approach is the agreed checkpoint to build from, so a fresh
+        │     session resumes without re-deriving it: gh issue view <plan>
         │   - If issue title contains [STORY-XXX], read docs/stories/STORY-XXX.md
         │     for full context (the user story and the need it serves)
         │   - If anything is unclear, ask the user before starting
@@ -114,4 +117,7 @@ history — start, failures, fixes, and resolution.
 - Branch naming convention: `issue-<number>-<short-slug>`
 - Always comment on the issue before and after implementation
 - Label management: `status:in-progress` while working, `status:blocked` if stuck
+- For a planned task, the linked plan issue (`Part of #<plan>`) holds the agreed
+  approach — the checkpoint a fresh session resumes from (see
+  `.claude/rules/dev-workflow.md`)
 ```

--- a/.claude/commands/dev-workflow/dw-plan.md
+++ b/.claude/commands/dev-workflow/dw-plan.md
@@ -1,129 +1,135 @@
-# Plan Development Work into GitHub Issues
+# Plan Development Work into a Plan Issue
 
 ```
-Break down a user request into GitHub Issues with labels and priorities.
+Research a story and write the plan — the agreed approach — as ONE GitHub plan
+issue, then stop for human review.
 
-Request: {{input}}
+Target: a STORY-XXX (or a raw request).
 
 ## PURPOSE
 
-Analyzes a feature request, enhancement, or bug report and creates well-structured
-GitHub Issues with proper labels and priorities. Checks for duplicates, breaks down
-multi-part requests, and waits for user approval before implementation begins.
+The front of the dev-workflow's build half: turn a story's *need* into an agreed
+*approach*, captured as a durable, reviewable **plan issue** before any task issue is
+opened. It researches against the repo (conventions, prior issues) so the plan is
+grounded, writes one plan issue, and **stops** — a human reviews the plan on GitHub,
+then `/dw-tasks` decomposes it. The plan issue is the parent of the task issues and the
+checkpoint a fresh session resumes from. See `.claude/rules/dev-workflow.md`.
+
+Fits in the dev-workflow:
+
+    dw-story → dw-review-story → dw-plan → [human reviews the plan issue]
+             → dw-tasks → dw-review-tasks → dw-implement → …
+
+This command produces the plan only. It does NOT create task issues — that is `/dw-tasks`.
 
 ---
 
 ## WORKFLOW
 
-    /dw-plan Add cross-repo sync commands
+    /dw-plan STORY-003
         │
-        ├─► Step 1: Check Existing Issues
-        │   - Run: gh issue list --state all --limit 50
-        │   - Scan for duplicates or related issues
-        │   - If duplicate found, report and ask user how to proceed
+        ├─► Step 1: Read the need (and right-size)
+        │   - If a STORY-XXX: read docs/stories/STORY-XXX.md (the need + "Success Looks Like").
+        │   - If a raw request: restate the need in a sentence.
+        │   - RIGHT-SIZE: if the work is trivial — a one-line change or a single,
+        │     obvious task — skip planning. Say so and hand off straight to
+        │     /dw-tasks (or a lone issue). The plan stage is for non-trivial stories.
         │
-        ├─► Step 2: Classify the Request
-        │   - Determine type: feature / enhancement / bug / docs
-        │   - Determine priority: high / medium / low
-        │   - Break down into individual issues if request covers multiple items
+        ├─► Step 2: Research (ground the approach)
+        │   - Investigate the repo so the plan reflects it, not generic advice:
+        │     • conventions — CLAUDE.md, .claude/rules/, neighbouring code patterns
+        │     • prior art — gh issue list --state all --limit 50 ; related stories
+        │   - Note the approach, the commands/files it will touch, and open questions.
         │
-        ├─► Step 3: Create Labels (idempotent)
-        │   - Ensure type labels exist:
-        │     • feature        (color: #0e8a16) — New capability
-        │     • enhancement    (color: #1d76db) — Improve existing
-        │     • bug            (color: #d93f0b) — Bug report
-        │     • docs           (color: #c5def5) — Documentation
-        │   - Ensure priority labels exist:
-        │     • priority:high   (color: #b60205) — Important, fix soon
-        │     • priority:medium (color: #fbca04) — Normal priority
-        │     • priority:low    (color: #0e8a16) — Nice to have
-        │   - Ensure status labels exist:
-        │     • status:in-progress  (color: #1d76db) — Work started
-        │     • status:needs-review (color: #e4e669) — PR open, awaiting review
-        │     • status:blocked      (color: #d93f0b) — Blocked by dependency
+        ├─► Step 3: Check for an existing plan
+        │   - Run: gh issue list --search "[STORY-XXX] Plan" --state all
+        │   - If a plan issue already exists, report and ask how to proceed (extend it,
+        │     not duplicate).
+        │
+        ├─► Step 4: Ensure labels (idempotent)
+        │   - plan           (color: #5319e7) — The approach for a story, before tasks
+        │   - priority:high / priority:medium / priority:low (as in /dw-tasks)
         │   - Use: gh label create "<name>" --color "<hex>" --description "<desc>" --force
         │
-        ├─► Step 4: Create Issues
-        │   - One issue per distinct work item
-        │   - Use the appropriate body template (see below)
-        │   - Apply type + priority labels
-        │   - Link related issues: "Depends on #N", "Related to #N"
+        ├─► Step 5: Write ONE plan issue
+        │   - Title: [STORY-XXX] Plan   (raw request: "Plan: <short need>")
+        │   - Body: the template below — approach, acceptance criteria, the
+        │     commands/files it expects to touch, open questions.
+        │   - Labels: plan + priority. Link the story: "Part of STORY-XXX".
         │
-        ├─► Step 5: Summarize
-        │   - Output a table of created issues:
-        │     | Issue | Title | Type | Priority | URL |
-        │   - Wait for user approval before proceeding
+        ├─► Step 6: Record on the story (if a STORY-XXX)
+        │   - Update docs/stories/STORY-XXX.md Status with the plan issue number:
+        │     - Plan: #<plan>
         │
-        └─► Step 6: User Approval Gate
-            - Ask: "Want me to start on #N?"
-            - Do NOT proceed to /dw-implement until user explicitly approves
+        └─► Step 7: Hand off — stop for human review
+            - Show the plan issue URL.
+            - STOP. The plan now waits for a HUMAN to read, comment, and approve it on
+              GitHub. Do NOT create task issues and do NOT auto-advance.
+            - Once a human is satisfied: /dw-tasks STORY-XXX breaks the plan into tasks.
 
 ---
 
-## ISSUE BODY TEMPLATES
+## PLAN ISSUE BODY TEMPLATE
 
-### Feature / Enhancement
+    ## Context
+    Part of [STORY-XXX](../docs/stories/STORY-XXX.md) — <the need, one line>.
 
-    ## User Story
-    As a [role], I want [capability], so that [benefit].
+    ## Approach
+    <How we'll meet the need — the agreed shape of the work, grounded in the repo.>
 
     ## Acceptance Criteria
-    1. ...
+    - [ ] <observable outcome that means the story is delivered>
 
-    ## Technical Notes
-    - ...
+    ## Touches
+    - <commands / files / areas the work is expected to change>
 
-    ## Dependencies
-    - None | Depends on #N
-
-### Bug
-
-    ## Description
-    ...
-
-    ## Expected Behavior
-    ...
-
-    ## Steps to Reproduce
-    1. ...
+    ## Open Questions
+    - <what's still unresolved — settled as the tasks are worked>
 
 ---
 
 ## EXAMPLE
 
-    /dw-plan Add command to generate release notes from git history
+    /dw-plan STORY-003
 
-**Agent creates:**
+**Agent reads the story, researches, writes one plan issue:**
 
-    gh issue create \
-      --label "feature" --label "priority:medium" \
-      --title "Add release notes generator command" \
-      --body "## User Story
-    As a developer, I want to generate release notes from git history,
-    so that I can quickly summarize changes for each release.
-
+    $ cat docs/stories/STORY-003.md
+    $ gh issue list --state all --limit 50
+    $ gh issue list --search "[STORY-003] Plan" --state all
+    $ gh label create "plan" --color "5319e7" --description "The approach for a story, before tasks" --force
+    $ gh issue create --label "plan" --label "priority:high" \
+        --title "[STORY-003] Plan" \
+        --body "## Context
+    Part of STORY-003 — validate inbound payloads.
+    ## Approach
+    ...
     ## Acceptance Criteria
-    1. Command reads git log between two tags
-    2. Groups commits by type (feature, fix, docs)
-    3. Outputs formatted markdown
+    - [ ] ...
+    ## Touches
+    - ...
+    ## Open Questions
+    - ..."
 
-    ## Dependencies
-    - None"
+**Story file updated:**
+
+    ## Status
+    - Created: 2026-04-01
+    - Plan: #28
 
 **Output:**
 
-    | Issue | Title                              | Type    | Priority | URL                    |
-    |-------|------------------------------------|---------|----------|------------------------|
-    | #27   | Add release notes generator command | feature | medium   | https://github.com/... |
-
-    Want me to start on #27?
+    Plan issue #28 created: https://github.com/owner/repo/issues/28
+    A human reviews + approves it; then /dw-tasks STORY-003 breaks it into tasks.
 
 ---
 
 ## API Notes
 
 - Uses `gh` CLI — must be authenticated (`gh auth status`)
-- Labels use `--force` flag so existing labels are updated, not duplicated
-- Always check for duplicates before creating new issues
-- The issue body is the single source of truth for the work item
+- Labels use `--force` so existing labels are updated, not duplicated
+- One plan issue per story — check for duplicates before creating
+- The plan issue is the parent of the task issues; the story records the need, the plan
+  records the approach, the task issues carry the how (see .claude/rules/dev-workflow.md)
+- Trivial work skips this command — go straight to /dw-tasks
 ```

--- a/.claude/commands/dev-workflow/dw-review-tasks.md
+++ b/.claude/commands/dev-workflow/dw-review-tasks.md
@@ -16,7 +16,8 @@ it's wrong.
 
 Fits between `/dw-tasks` (creates issues) and `/dw-implement` (works one):
 
-    dw-story → dw-review-story → dw-tasks → dw-review-tasks → dw-implement → …
+    dw-story → dw-review-story → dw-plan → [human reviews the plan issue]
+             → dw-tasks → dw-review-tasks → dw-implement → …
 
 ---
 
@@ -27,14 +28,19 @@ Fits between `/dw-tasks` (creates issues) and `/dw-implement` (works one):
         ├─► Step 1: Gather
         │   - If no story ID, list docs/stories/ and ask which to review
         │   - Read docs/stories/STORY-XXX.md (the goal + "Success Looks Like")
-        │   - List its issues:
+        │   - Find the plan issue (if any): note its number <plan> — none means
+        │     trivial work that skipped the plan stage:
+        │     gh issue list --search "[STORY-XXX] Plan" --label plan --state all
+        │   - List its task issues (the plan issue is the parent, not a task):
         │     gh issue list --search "[STORY-XXX]" --state all --json number,title,labels,body
         │   - If no issues exist, report and stop (run /dw-tasks first)
         │
-        ├─► Step 2: Coverage — the issues vs the story
+        ├─► Step 2: Coverage — the issues vs the story (and plan)
         │   - [ ] Every item in the story's "Success Looks Like" is covered by an issue
         │   - [ ] Nothing essential to delivering the story is missing
         │   - [ ] No issue goes beyond the story's goal — each traces back to the need
+        │   - [ ] When a plan exists: each task links back to it ("Part of #<plan>") —
+        │         flag any task missing the link. No plan → skip (trivial path).
         │
         ├─► Step 3: Each issue
         │   - [ ] One clear job (title + Goal say one thing)

--- a/.claude/commands/dev-workflow/dw-story.md
+++ b/.claude/commands/dev-workflow/dw-story.md
@@ -71,7 +71,9 @@ proof of concept, or clarification. The "how" goes here, not above.]
 
 Show the user the created story and suggest next steps:
 - `/dw-review-story STORY-XXX` to check it's complete and still a goal, not a spec
-- `/dw-tasks STORY-XXX` to open GitHub issue(s) where the *how* gets worked out
+- `/dw-plan STORY-XXX` to research the approach and write the plan issue (the agreed
+  *how*), reviewed before it's broken into tasks
+- Trivial / single-task work can skip the plan — `/dw-tasks STORY-XXX` straight away
 - `/qw-plan` to plan what to test (if QA-related)
 
 ---

--- a/.claude/commands/dev-workflow/dw-tasks.md
+++ b/.claude/commands/dev-workflow/dw-tasks.md
@@ -1,19 +1,22 @@
-# Break Story into GitHub Issues
+# Break a Plan into GitHub Task Issues
 
 ```
-Read a user story file and create GitHub issues for each task.
+Break a reviewed plan (or a story) into GitHub task issues, each linked back to it.
 
 Story ID: {{input}}
 
 ## PURPOSE
 
-Reads an existing story file from `docs/stories/STORY-XXX.md` and breaks it into
-implementable GitHub issues. Each issue is linked back to the story via title prefix.
-Updates the story file with created issue numbers.
+Reads the reviewed **plan issue** for a story (`[STORY-XXX] Plan`, written by `/dw-plan`)
+and breaks its approach into implementable GitHub task issues, each linking back to the
+plan. When no plan issue exists — trivial work that skipped the plan stage — it falls
+back to breaking the story directly. Updates the story file with the created issue
+numbers. See `.claude/rules/dev-workflow.md`.
 
-Fits between `/dw-story` (creates story) and `/dw-implement` (works on an issue):
+Fits in the dev-workflow:
 
-    dw-story → dw-tasks → dw-implement → dw-create-pr → [human review + test] → dw-merge
+    dw-story → dw-review-story → dw-plan → [human reviews the plan issue]
+             → dw-tasks → dw-review-tasks → dw-implement → …
 
 ---
 
@@ -21,15 +24,19 @@ Fits between `/dw-story` (creates story) and `/dw-implement` (works on an issue)
 
     /dw-tasks STORY-003
         │
-        ├─► Step 1: Read the Story
+        ├─► Step 1: Read the plan (or the story)
         │   - If no story ID provided, list files in docs/stories/ and ask user to pick
-        │   - Read docs/stories/STORY-XXX.md
-        │   - Extract: the need and what success looks like (the story holds the
-        │     goal, not a spec — there are no technical notes to copy out)
+        │   - Read docs/stories/STORY-XXX.md for the need + "Success Looks Like"
+        │   - Find the reviewed plan issue:
+        │     gh issue list --search "[STORY-XXX] Plan" --label plan --state open
+        │     • If found: read it — its Approach + Acceptance Criteria are what you
+        │       break into tasks (the plan is the agreed how). Note its number <plan>.
+        │     • If none: fall back to breaking the story directly (trivial work that
+        │       skipped the plan stage). <plan> is empty.
         │   - If the story file doesn't exist, report and stop
         │
         ├─► Step 2: Break into Tasks
-        │   - Analyze the story and break it into tasks
+        │   - Break the plan's approach (or the story, when no plan) into tasks
         │   - Each task should be:
         │     • Small — completable in one session
         │     • Independent — minimal dependencies between tasks
@@ -56,15 +63,16 @@ Fits between `/dw-story` (creates story) and `/dw-implement` (works on an issue)
         │   - Body — start lean; the issue grows as the *how* is worked out
         │     (research, PoC, clarification, fixes) and recorded in comments:
         │       ## Context
-        │       Part of [STORY-XXX](../docs/stories/STORY-XXX.md)
+        │       Part of [STORY-XXX](../docs/stories/STORY-XXX.md) · plan #<plan>
         │
         │       ## Goal
-        │       [what this task achieves, from the story's need]
+        │       [what this task achieves, from the plan's approach / the story's need]
         │
         │       ## Done When
         │       - [ ] [observable done condition for this task]
-        │   - Labels: type + priority (infer from story content)
-        │   - Link related issues: "Part of STORY-XXX"
+        │   - Labels: type + priority (infer from the plan / story content)
+        │   - Trace back: "Part of #<plan>" in the body links each task to the plan
+        │     issue (GitHub backlinks it). Omit the plan reference when there is none.
         │
         ├─► Step 6: Update Story File
         │   - Update the Status section in docs/stories/STORY-XXX.md:
@@ -85,13 +93,14 @@ Fits between `/dw-story` (creates story) and `/dw-implement` (works on an issue)
 
     /dw-tasks STORY-003
 
-**Agent reads story, breaks into tasks, creates issues:**
+**Agent reads the plan, breaks it into tasks, creates issues:**
 
     $ cat docs/stories/STORY-003.md
-    $ gh issue list --search "[STORY-003]" --state all
+    $ gh issue list --search "[STORY-003] Plan" --label plan --state open   # → plan #28
+    $ gh issue list --search "[STORY-003]" --state all                      # dup check
     $ gh issue create --title "[STORY-003] Add input validation" \
         --label "enhancement" --label "priority:high" \
-        --body "## Context\nPart of STORY-003\n\n## Goal\n...\n\n## Done When\n- [ ] ..."
+        --body "## Context\nPart of STORY-003 · plan #28\n\n## Goal\n...\n\n## Done When\n- [ ] ..."
     $ gh issue create --title "[STORY-003] Add error response formatting" \
         --label "enhancement" --label "priority:medium" \
         --body "..."
@@ -119,6 +128,8 @@ Fits between `/dw-story` (creates story) and `/dw-implement` (works on an issue)
 - Uses `gh` CLI for issue operations
 - Story files live in `docs/stories/STORY-XXX.md` (created by /dw-story)
 - Issue titles use `[STORY-XXX]` prefix for traceability
+- The reviewed plan issue (`[STORY-XXX] Plan`, from /dw-plan) is the source for the
+  breakdown when present, and each task links back to it; no plan → break the story
 - The story file records the need; the issue is the single source of truth for *how*,
   growing with research, decisions, and fixes as the work proceeds
 ```

--- a/.claude/commands/dev-workflow/dw-test-design.md
+++ b/.claude/commands/dev-workflow/dw-test-design.md
@@ -124,7 +124,7 @@ Fits into the dev-workflow chain after /dw-implement and before /dw-create-pr.
 **Generates YAML test case:**
 
     Created: cicd/tests/testcases/integration/TC-INTEGRATION-002.yml
-    Running: npm test -- --suite integration
+    Running: npm test -- --suite integration --no-llm
     Result: 2 tests passed (0 failed)
 
     Next: /dw-create-pr 47

--- a/.claude/rules/dev-workflow.md
+++ b/.claude/rules/dev-workflow.md
@@ -1,0 +1,73 @@
+---
+paths:
+  - ".claude/commands/dev-workflow/**/*.md"
+---
+
+# dev-workflow
+
+Turns a need into shipped code. A story states the **need** (a goal, not a spec); a
+**plan issue** states the agreed **approach**; task issues carry the *how* as it's worked
+out. Each producer is paired with a review — the same discipline `qa-workflow` and
+`reviewing-artifacts` enforce.
+
+## The flow
+
+```
+   docs/stories/STORY-XXX.md
+            │
+   dw-story ───────► dw-review-story    the need — complete, and a goal not a spec
+            │
+            ▼
+   dw-plan ────────► [human reviews the plan issue]   research → ONE plan issue: the approach
+            │                                           (skip for trivial / single-task work)
+            ▼
+   dw-tasks ───────► dw-review-tasks    plan issue → task issues, each "Part of #<plan>"
+            │
+            ▼
+   dw-implement ───► dw-review-implement   build the issue; the plan issue is the
+            │                               checkpoint a fresh session resumes from
+            ▼
+   dw-create-pr ───► [human review + /review]   open the PR
+            │
+            ▼
+   dw-merge          green CI + human review → merge
+```
+
+## The plan issue
+
+The plan is a **GitHub issue**, one per story, labelled `plan`, titled `[STORY-XXX] Plan`.
+Its body holds the researched approach, acceptance criteria, and the commands/files it
+expects to touch. It is the **parent** of the task issues (`dw-tasks` links each task back
+with "Part of #<plan>"), and the durable checkpoint that survives a lost session.
+
+Its review is a **human gate**: a person reads, comments, and approves the issue on GitHub
+before `dw-tasks` decomposes it — no `dw-*` command produces or gates it (mirrors the
+`[human review + /review]` gate before a merge).
+
+## Producer → review pairing
+
+| Producer | Review | Covers |
+|----------|--------|--------|
+| `dw-story`     | `dw-review-story`     | the need: complete, and a goal not a spec |
+| `dw-plan`      | **human review** (the plan issue) | the approach covers the story, before decomposition |
+| `dw-tasks`     | `dw-review-tasks`     | the issues cover the plan; each lean; trace back to the plan |
+| `dw-implement` | `dw-review-implement` | the change delivers the issue, surgical, fits the studio |
+| `dw-test-design` | *(verified by running the suite)* | tests pass, native to the framework |
+| `dw-create-pr` | *(human review + `/review`)* | the PR overview before merge |
+| `dw-merge`     | *(is the terminal gate)* | green CI + human review |
+
+No producer ships without a review covering its output.
+
+## Right-size it
+
+The plan stage is for non-trivial stories. A one-line doc change or a single-task story
+**skips `dw-plan`** — `dw-story` hands off straight to `dw-tasks` (or a lone issue). Three
+review passes plus a plan issue on a typo is ritual, not rigor (see CLAUDE.md §5).
+
+## What is reused, not rebuilt
+
+- **The story + issues** are shared with `qa-workflow` — one `STORY-XXX` gets both `dw-*`
+  (code) and `qw-*` (tests).
+- **GitHub issues** already hold the work; the plan is one too (the parent), so the
+  approach, its review, and its history live where the tasks do — no separate plan store.
+- **CI** is the project's existing checks + human review — the merge gate, not a new pipeline.


### PR DESCRIPTION
## Summary
Bring this repo's dev-workflow up to the plan-stage version from `ai-qa-step-graph`:
- **dw-plan** now produces a durable `[STORY-XXX] Plan` GitHub issue (researched approach), **human-reviewed**, before **dw-tasks** breaks it into task issues that link back (`Part of #<plan>`); **dw-implement** reads the plan as a resumable checkpoint; **dw-review-tasks** checks the trace-back.
- Adds `.claude/rules/dev-workflow.md` — the flow diagram + producer→review pairing the commands cite.
- Genericized the source repo's specifics: dropped the STORY-008 status marker and changed `make ci`/STORY-002 references to "the project's CI" (this repo has no `make ci`).

Dev-workflow only — qa-workflow and CLAUDE.md are separate passes.

## Test plan
- [ ] `.claude/commands/dev-workflow/` has the 10 plan-stage commands; `dw-plan` titled "Plan Development Work into a Plan Issue"
- [ ] `.claude/rules/dev-workflow.md` present; no dangling `make ci`/STORY-002/STORY-008 refs
- [ ] Cross-refs (`docs/stories/`, `qa-workflow`, `reviewing-artifacts`, CLAUDE.md §5) resolve in this repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)