### PR TITLE
Relocate the bind/drift code into the runner (cicd/tests/src/) (#20)

### DIFF
--- a/cicd/tests/package.json
+++ b/cicd/tests/package.json
@@ -11,7 +11,10 @@
     "test:integration": "tsx src/cli.ts run --suite integration",
     "test:e2e": "tsx src/cli.ts run --suite e2e",
     "list": "tsx src/cli.ts list",
-    "dev": "tsx src/cli.ts"
+    "dev": "tsx src/cli.ts",
+    "audit-bind": "tsx src/audit-bind.ts",
+    "drift": "tsx src/drift.ts",
+    "port-yaml": "tsx src/port-yaml.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.102.0",

--- a/cicd/tests/src/audit-bind.ts
+++ b/cicd/tests/src/audit-bind.ts
@@ -1,0 +1,90 @@
+/**
+ * STORY-004 #25: audit that each test doc and its bound executable agree.
+ *
+ * Binding is *audit, not codegen* (#21): the markdown owns intent, the cicd YAML
+ * owns execution. This checks, per case (TC), that the binding still holds:
+ *   - the `Script:` path resolves to a file, and
+ *   - the doc's step count matches the YAML's step count (a structural drift
+ *     signal — if the executable gains/loses steps without the doc following,
+ *     the pair has diverged).
+ * A case that fails is `unbound`. Exits non-zero if any case is unbound, so CI
+ * (and the drift gate, #27) can gate on it.
+ *
+ * Run: npm run audit-bind
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { readScenario, scenarioFiles } from './testdoc.js';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');  // cicd/tests/src → repo root
+const TESTS_DIR = join(REPO_ROOT, 'docs', 'tests');
+
+export interface BindFinding {
+  doc: string;
+  tc: string;
+  bound: boolean;
+  detail: string;
+}
+
+/**
+ * Count step entries (`- name:`) inside the top-level `steps:` block of a cicd
+ * YAML — anchored to `steps:` so a `- name:` under some other list (a future
+ * `matrix:`, `hooks:`, …) doesn't inflate the count.
+ *
+ * This is a structural signal: equal counts mean "same number of steps", not
+ * "same steps" — a count-preserving edit (swap/reorder) stays `bound`. That is
+ * the floor for an audit-not-codegen design; semantic agreement is the
+ * reviewer's job in /qw-review-bind.
+ */
+function yamlStepCount(path: string): number {
+  let inSteps = false;
+  let n = 0;
+  for (const line of readFileSync(path, 'utf8').split('\n')) {
+    if (/^steps:\s*$/.test(line)) { inSteps = true; continue; }
+    if (inSteps && /^\S/.test(line)) inSteps = false; // dedent to the next top-level key
+    if (inSteps && /^\s*-\s+name:/.test(line)) n++;
+  }
+  return n;
+}
+
+/** Audit every case in every docs/tests/ scenario; returns one finding per case. */
+export function auditBindings(): BindFinding[] {
+  const findings: BindFinding[] = [];
+  for (const f of scenarioFiles(TESTS_DIR)) {
+    const { cases } = readScenario(join(TESTS_DIR, f));
+    for (const c of cases) {
+      if (!c.script) {
+        findings.push({ doc: f, tc: c.tc, bound: false, detail: 'no Script: binding' });
+        continue;
+      }
+      const scriptPath = join(REPO_ROOT, c.script);
+      if (!existsSync(scriptPath)) {
+        findings.push({ doc: f, tc: c.tc, bound: false, detail: `script not found: ${c.script}` });
+        continue;
+      }
+      const docN = c.steps.length;
+      const yamlN = yamlStepCount(scriptPath);
+      if (docN !== yamlN) {
+        findings.push({
+          doc: f, tc: c.tc, bound: false,
+          detail: `step count diverged: doc=${docN} vs ${c.script}=${yamlN}`,
+        });
+        continue;
+      }
+      findings.push({ doc: f, tc: c.tc, bound: true, detail: `${docN} steps ↔ ${c.script}` });
+    }
+  }
+  return findings;
+}
+
+// Run as a script: print findings, exit non-zero if anything is unbound.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const findings = auditBindings();
+  for (const f of findings) {
+    console.log(`${f.bound ? 'bound  ' : 'UNBOUND'}  ${f.doc} ${f.tc} — ${f.detail}`);
+  }
+  const unbound = findings.filter((f) => !f.bound).length;
+  console.log(`\n${findings.length} case(s), ${unbound} unbound`);
+  process.exit(unbound > 0 ? 1 : 0);
+}

--- a/cicd/tests/src/drift.ts
+++ b/cicd/tests/src/drift.ts
@@ -1,0 +1,73 @@
+/**
+ * STORY-004 #27: the freshness gate — surface tests that no longer match.
+ *
+ * Drift is silent until something checks. Two deterministic signals, per the
+ * qa-workflow design:
+ *   - STALE   — the linked story changed since the test was last synced
+ *               (its sha256 no longer matches the doc's `story_hash`).
+ *   - UNBOUND — the doc and its bound executable have diverged (reuses the
+ *               #25 audit, audit-bind.ts).
+ * Exits non-zero if any test is stale or unbound, so CI fails on drift and a
+ * green build means "these tests still match their stories".
+ *
+ * (Hash-first is deterministic and needs no stack. A semantic, embedding-based
+ * signal — softer "drifted in meaning" — is a later, advisory add.)
+ *
+ * Run: npm run drift
+ */
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { readScenario, scenarioFiles } from './testdoc.js';
+import { auditBindings } from './audit-bind.js';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');  // cicd/tests/src → repo root
+const TESTS_DIR = join(REPO_ROOT, 'docs', 'tests');
+
+function sha256(path: string): string {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+interface Stale {
+  doc: string;
+  detail: string;
+}
+
+/** Flag every scenario whose linked story has moved since last sync. */
+function staleDocs(): Stale[] {
+  const stale: Stale[] = [];
+  for (const f of scenarioFiles(TESTS_DIR)) {
+    const { frontMatter: fm } = readScenario(join(TESTS_DIR, f));
+    const story = fm.story;
+    if (!story) {
+      stale.push({ doc: f, detail: 'no story: link' });
+      continue;
+    }
+    const storyFile = join(REPO_ROOT, 'docs', 'stories', `${story}.md`);
+    if (!existsSync(storyFile)) {
+      stale.push({ doc: f, detail: `story file missing: docs/stories/${story}.md` });
+      continue;
+    }
+    const have = sha256(storyFile);
+    if (fm.story_hash !== have) {
+      stale.push({ doc: f, detail: `${story} changed since sync (re-check, then update story_hash)` });
+    }
+  }
+  return stale;
+}
+
+const docCount = scenarioFiles(TESTS_DIR).length;
+const stale = staleDocs();
+const unbound = auditBindings().filter((b) => !b.bound);
+
+for (const s of stale) console.log(`STALE    ${s.doc} — ${s.detail}`);
+for (const u of unbound) console.log(`UNBOUND  ${u.doc} ${u.tc} — ${u.detail}`);
+
+// A clean run over zero docs is "nothing checked", not "all good" — surface it.
+if (docCount === 0) console.log('WARNING: no test docs in docs/tests/ — the drift gate checked nothing.');
+
+const problems = stale.length + unbound.length;
+console.log(`\n${docCount} doc(s): ${stale.length} stale, ${unbound.length} unbound`);
+if (problems === 0) console.log('drift check clean — tests still match their stories.');
+process.exit(problems > 0 ? 1 : 0);

--- a/cicd/tests/src/port-yaml.ts
+++ b/cicd/tests/src/port-yaml.ts
@@ -1,0 +1,68 @@
+/**
+ * STORY-004 #25: port an existing cicd YAML into a markdown test-doc scaffold.
+ *
+ * The "revert direction" — bootstrap a human-readable test doc *from* an
+ * executable that already exists, so the in-repo apparatus gets its canonical
+ * half without re-authoring it. The output is a scaffold: it carries the steps
+ * and the `Script:` binding; the objective, expected results, and story link
+ * are TODOs for a human/agent to fill, then `qw-review-bind` audits the result.
+ *
+ * Run: npm run port-yaml -- cicd/tests/testcases/build/TC-BUILD-001.yml > docs/tests/TS-NN-slug.md
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, isAbsolute } from 'node:path';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');  // cicd/tests/src → repo root
+
+const rel = process.argv[2];
+if (!rel) {
+  console.error('usage: npm run port-yaml -- <repo-relative/path/to/TC-*.yml>');
+  process.exit(2);
+}
+// Accept a repo-relative path (the `Script:` form) regardless of cwd.
+const yaml = readFileSync(isAbsolute(rel) ? rel : join(REPO_ROOT, rel), 'utf8');
+
+const name = yaml.match(/^name:\s*(.*)$/m)?.[1]?.trim() ?? 'Ported scenario';
+
+// Each step starts at `  - name:`; its block runs to the next step or EOF.
+// Escape pipes so a cell containing `|` (a regex alternation, a shell `||`)
+// stays one cell when the doc is parsed back (testdoc.tableCells).
+const esc = (s: string) => s.replace(/\|/g, '\\|');
+
+const stepRe = /^\s*-\s+name:\s*(.*)$/gm;
+const marks = [...yaml.matchAll(stepRe)];
+const rows = marks.map((m, i) => {
+  const start = m.index! + m[0].length;
+  const end = i + 1 < marks.length ? marks[i + 1].index! : yaml.length;
+  const block = yaml.slice(start, end);
+  const command = block.match(/^\s*command:\s*(.*)$/m)?.[1]?.trim();
+  const expect = block.match(/expectPatterns:\s*\n\s*-\s*"?([^"\n]+)"?/)?.[1]?.trim();
+  const action = command ? `${m[1].trim()} (\`${command}\`)` : m[1].trim();
+  return `| ${i + 1} | ${esc(action)} | ${esc(expect ?? 'TODO')} |`;
+});
+
+process.stdout.write(`---
+id: TS-NN
+title: ${name}
+namespace: TODO
+story: STORY-NNN
+issue: TODO
+status: unbound
+story_hash: TODO
+---
+
+## Why this scenario exists
+
+TODO: link this to the story's need.
+
+### TC-01: ${name}
+
+- **Objective:** TODO
+- **Script:** ${rel}
+- **Preconditions:** TODO
+
+| # | Action | Expected Result |
+|---|--------|-----------------|
+${rows.join('\n')}
+`);

--- a/cicd/tests/src/testdoc.ts
+++ b/cicd/tests/src/testdoc.ts
@@ -1,0 +1,105 @@
+/**
+ * STORY-004: the one parser for a docs/tests/ scenario doc.
+ *
+ * Shared by the loader (#26) and the bind audit (#25) so there is a single
+ * reading of the format — two parsers would be their own drift risk.
+ */
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+
+export interface TestCase {
+  tc: string;        // "TC-01"
+  title: string;
+  objective: string | null; // the case's "what it verifies", or null if absent
+  script: string | null; // the bound cicd YAML path, or null if unbound
+  steps: { action: string; expected: string }[];
+}
+
+export interface Scenario {
+  frontMatter: Record<string, string>;
+  cases: TestCase[];
+}
+
+/** Parse `key: value` front-matter between the first pair of `---` fences. */
+export function parseFrontMatter(md: string): Record<string, string> {
+  const m = md.match(/^---\n([\s\S]*?)\n---/);
+  const fm: Record<string, string> = {};
+  if (!m) return fm;
+  for (const line of m[1].split('\n')) {
+    const kv = line.match(/^([A-Za-z_]+):\s*(.*?)\s*$/);
+    if (kv) fm[kv[1]] = kv[2];
+  }
+  return fm;
+}
+
+/**
+ * Split a markdown table row into trimmed cells. Splits on *unescaped* pipes
+ * only and unescapes `\|`, so a cell may legitimately contain a literal pipe
+ * (a regex like `ok|healthy`, a shell `... || echo`).
+ */
+function tableCells(row: string): string[] {
+  return row
+    .replace(/^\s*\|/, '')
+    .replace(/\|\s*$/, '')
+    .split(/(?<!\\)\|/)
+    .map((c) => c.replace(/\\\|/g, '|').trim());
+}
+
+/** The scenario docs in a docs/tests/ dir, in stable order ([] if the dir is absent). */
+export function scenarioFiles(dir: string): string[] {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir).filter((f) => f.endsWith('.md') && f !== 'README.md').sort();
+}
+
+/** Parse a scenario file into its front-matter and cases (each with its steps). */
+export function parseScenario(md: string): Scenario {
+  const frontMatter = parseFrontMatter(md);
+  const cases: TestCase[] = [];
+
+  // Each `### TC-NN: title` starts a case; its block runs to the next ### or EOF.
+  const tcRe = /^###\s+(TC-\d+):\s*(.*)$/gm;
+  const matches = [...md.matchAll(tcRe)];
+  for (let i = 0; i < matches.length; i++) {
+    const start = matches[i].index! + matches[i][0].length;
+    const end = i + 1 < matches.length ? matches[i + 1].index! : md.length;
+    const block = md.slice(start, end);
+
+    const steps: TestCase['steps'] = [];
+    for (const line of block.split('\n')) {
+      if (!line.trim().startsWith('|')) continue;
+      const cells = tableCells(line);
+      // skip header (`# | Action | …`) and separator; data rows start with a number
+      if (cells.length < 3 || !/^\d+$/.test(cells[0])) continue;
+      steps.push({ action: cells[1], expected: cells[2] });
+    }
+
+    cases.push({
+      tc: matches[i][1],
+      title: matches[i][2].trim(),
+      // [ \t]* not \s* — \s would cross the newline of an empty `**Objective:**`
+      // line and capture the next line (e.g. the Script line) as the objective.
+      objective: block.match(/\*\*Objective:\*\*[ \t]*(.+)/)?.[1]?.trim() ?? null,
+      script: block.match(/\*\*Script:\*\*\s*(\S+)/)?.[1] ?? null,
+      steps,
+    });
+  }
+  return { frontMatter, cases };
+}
+
+/** Read and parse a scenario file from disk. */
+export function readScenario(file: string): Scenario {
+  return parseScenario(readFileSync(file, 'utf8'));
+}
+
+/** The searchable step text for one row: "Action — Expected" (or just Action). */
+export function stepText(s: { action: string; expected: string }): string {
+  return s.expected && s.expected !== '—' ? `${s.action} — ${s.expected}` : s.action;
+}
+
+/**
+ * The searchable text for a case-level row: its title and objective — *what the
+ * case verifies*, the level an agent searches by. Falls back to the title alone
+ * when a case has no objective.
+ */
+export function caseText(c: { title: string; objective: string | null }): string {
+  return c.objective ? `${c.title} — ${c.objective}` : c.title;
+}


### PR DESCRIPTION
## Summary
Group **B** (run the tests) moves next to the runner this repo owns. From ai-qa-step-graph's STORY-011 factoring:
- Copy the **DB-free** binding/drift logic — `audit-bind.ts` · `drift.ts` · `port-yaml.ts` · `testdoc.ts` — into `cicd/tests/src/`.
- Fix `REPO_ROOT` for the deeper path (`cicd/tests/src/` → repo root, so `docs/tests/` resolves).
- Add `audit-bind` / `drift` / `port-yaml` npm scripts to `cicd/tests/package.json` (tsx already a devDep).

**No step-store / DB dependency** — imports are `node:fs`/`path`/`crypto` + the relative `./testdoc.js`/`./audit-bind.js` only.

Fixes #20 · Part of ai-qa-step-graph STORY-011 / plan `dogkeeper886/ai-qa-step-graph#121`.

> Follow-up #21 adds `docs/tests/README.md` (the format) + repoints the qa-workflow commands at `npm --prefix cicd/tests`.

## Test plan
- [x] `npm --prefix cicd/tests run drift` → "0 doc(s)… drift check clean", exit 0
- [x] `npm --prefix cicd/tests run audit-bind` → "0 case(s), 0 unbound", exit 0
- [x] No `db`/`embed`/`mcp` imports (DB-free)
- [ ] End-to-end path proof (drift finds a real doc) — lands with #21's `docs/tests/`

Generated with [Claude Code](https://claude.com/claude-code)