### PR TITLE
Repoint the B commands at cicd/tests + add the docs/tests format (#21)

### DIFF
--- a/.claude/commands/qa-workflow/qw-bind.md
+++ b/.claude/commands/qa-workflow/qw-bind.md
@@ -15,8 +15,8 @@ link still holds.
 
 Fits in the qa-workflow:
 
-    qw-plan → qw-cases → qw-bind → qw-review-bind → qw-run → qw-merge
-    (qw-run = `make up` + the cicd runner — a phase, not a slash command)
+    qw-plan → qw-cases → qw-bind → qw-review-bind → qw-run → dw-merge
+    (qw-run = `npm test` — the cicd runner; a phase, not a slash command)
 
 ---
 
@@ -37,7 +37,7 @@ Fits in the qa-workflow:
     /qw-bind cicd/tests/testcases/build/TC-BUILD-001.yml
         │
         ├─► Generate a scaffold from the YAML:
-        │     npm --prefix step-store run port-yaml -- <yaml> > docs/tests/TS-NN-<slug>.md
+        │     npm --prefix cicd/tests run port-yaml -- <yaml> > docs/tests/TS-NN-<slug>.md
         │   The scaffold carries the steps and the `Script:` binding; objective,
         │   expected results, story link, and namespace are TODOs.
         ├─► Fill the TODOs: `namespace`, `story` (+ `story_hash`), each TC's
@@ -49,6 +49,6 @@ Fits in the qa-workflow:
 ## API Notes
 
 - `port-yaml` is a scaffolder, not a translator — a human/agent fills meaning.
-- `story_hash` = `sha256sum docs/stories/STORY-XXX.md` (the drift anchor, #27).
+- `story_hash` = `sha256sum docs/stories/STORY-XXX.md` (the drift anchor).
 - Producer paired with `/qw-review-bind` (the audit).
 ```

--- a/.claude/commands/qa-workflow/qw-drift.md
+++ b/.claude/commands/qa-workflow/qw-drift.md
@@ -14,7 +14,7 @@ this looks, deterministically, every run.
 
 Fits in the qa-workflow:
 
-    … → qw-run → [human] → dw-merge   (qw-run = `make up` + the cicd runner, not a slash command)
+    … → qw-run → [human] → dw-merge   (qw-run = `npm test` — the cicd runner, not a slash command)
                     └──────────────► qw-drift ──► back to qw-cases when stale
 
 ---
@@ -23,7 +23,7 @@ Fits in the qa-workflow:
 
     /qw-drift
         │
-        ├─► Run the gate:  npm --prefix step-store run drift
+        ├─► Run the gate:  npm --prefix cicd/tests run drift
         │   Two deterministic signals, per case/scenario:
         │     - STALE   — the linked story's sha256 no longer matches the doc's
         │                 `story_hash` (the story moved since the test was synced).
@@ -41,7 +41,7 @@ Fits in the qa-workflow:
 
 ## API Notes
 
-- Hash-first is deterministic and needs no stack; it runs in CI (`.github/workflows/qa-drift.yml`).
+- Hash-first is deterministic and needs no stack; it runs in CI and on demand.
 - A semantic, embedding-based signal (softer "drifted in meaning", via the store)
   is a planned advisory add — hash is the build-failing gate.
 - `status` in a test doc (green | stale | unbound) reflects this gate's verdict.

--- a/.claude/commands/qa-workflow/qw-review-bind.md
+++ b/.claude/commands/qa-workflow/qw-review-bind.md
@@ -14,8 +14,8 @@ deterministic audit and adds a human/agent pass for meaning.
 
 Fits in the qa-workflow:
 
-    qw-plan → qw-cases → qw-bind → qw-review-bind → qw-run → qw-merge
-    (qw-run = `make up` + the cicd runner — a phase, not a slash command)
+    qw-plan → qw-cases → qw-bind → qw-review-bind → qw-run → dw-merge
+    (qw-run = `npm test` — the cicd runner; a phase, not a slash command)
 
 ---
 
@@ -24,7 +24,7 @@ Fits in the qa-workflow:
     /qw-review-bind
         │
         ├─► Step 1: Run the deterministic audit
-        │     npm --prefix step-store run audit-bind
+        │     npm --prefix cicd/tests run audit-bind
         │   For each case it checks:
         │     - the `Script:` path resolves to a file, and
         │     - the doc's step count matches the YAML's step count.

--- a/docs/tests/README.md
+++ b/docs/tests/README.md
@@ -1,0 +1,77 @@
+# `docs/tests/` — the test-doc format
+
+Each test is a **readable markdown document** that lives here, close to the story it verifies.
+The markdown owns **why / what** (intent); the bound `cicd/` YAML owns **how it runs**
+(execution). `qw-bind` links them, `qw-review-bind` audits the link, and `qw-drift` watches
+for divergence — all via `npm --prefix cicd/tests` (`audit-bind` / `drift` / `port-yaml`).
+
+## One file = one scenario (TS), many cases (TC)
+
+A **scenario** groups related **cases**, each case a sequence of **steps**.
+
+```
+docs/tests/
+  TS-01-<slug>.md     # a scenario: TC-01, TC-02, … each with a Steps table
+  TS-02-….md
+```
+
+- **TS** (scenario) — the file. Holds the front-matter and a `## Why this scenario exists`.
+- **TC** (case) — a `### TC-NN:` section. Has an objective, a **`Script:`** line (the bound
+  `cicd/` YAML), and a **Steps** table.
+- **Step** — one row of a case's Steps table: an **Action** and its **Expected Result**. The
+  audit treats the doc's step count vs the YAML's step count as the binding check.
+
+## Front-matter (scenario level)
+
+```yaml
+---
+id: TS-01                       # scenario id, unique within the namespace
+title: Stack builds and runs its lifecycle
+namespace: test-framework       # which repo/tenant this test belongs to
+story: STORY-001                # the need this scenario verifies (→ docs/stories/STORY-001.md)
+story_hash: 7474d8b6…           # sha256 of the linked story file at last sync (drift anchor)
+plan: 28                        # the [STORY-XXX] Test Plan issue it was authored from (optional)
+status: green                   # green | stale | unbound  (maintained by qw-drift)
+---
+```
+
+- `story` + `story_hash` are the **drift anchor**: when the story changes, its hash no longer
+  matches and `qw-drift` flags the scenario `stale`.
+- The **`Script:` binding is per-TC, not in front-matter** — a scenario's cases can map to
+  different executables.
+
+## Case (TC) structure
+
+```markdown
+### TC-01: Project build verification
+
+- **Objective:** the stack builds from a clean checkout.
+- **Script:** cicd/tests/testcases/build/TC-BUILD-001.yml
+- **Preconditions:** Node and npm available.
+
+| # | Action | Expected Result |
+|---|--------|-----------------|
+| 1 | Run `node --version` | prints `vNN.NN.NN` |
+| 2 | Run `npm install` | completes without error |
+```
+
+The Steps table is **machine-extractable** on purpose: one row = one `Action → Expected Result`,
+and the row count is what `audit-bind` compares to the YAML's `steps:`.
+
+## Binding, running, drift (this repo's job)
+
+- **Bind** (`qw-bind`): set each TC's `Script:` to the `cicd/tests/testcases/**/*.yml` that runs
+  it. Or revert: `npm --prefix cicd/tests run port-yaml -- <yaml>` scaffolds a doc from a YAML.
+- **Audit** (`qw-review-bind`): `npm --prefix cicd/tests run audit-bind` — the `Script:` resolves
+  and the step counts match, else `unbound`.
+- **Run**: `npm test` (the cicd assert-first runner).
+- **Drift** (`qw-drift`): `npm --prefix cicd/tests run drift` — `stale` if `story_hash` no longer
+  matches the story; `unbound` if a doc and its script diverged.
+
+## Traceability
+
+- **story → tests:** `grep -l 'story: STORY-XXX' docs/tests/`
+- **test → story / script:** the front-matter `story:` and each case's `Script:` line.
+- **script → test:** the `Script:` path points at the YAML.
+
+No hand-maintained index — the links live in the files and resolve by `grep`/path.


### PR DESCRIPTION
## Summary
Finishes group **B**'s arrival (STORY-011, after #20 brought the code):
- **`qw-bind` / `qw-review-bind` / `qw-drift`** now call `npm --prefix cicd/tests` (port-yaml / audit-bind / drift), not `step-store`; the run phase is **`npm test`**, not `make up`.
- **`docs/tests/README.md`** — the format contract (front-matter, TC + `Script:` binding, Steps, drift) the bind/drift code operates on.

**End-to-end proof** (closes #20's deferred check): `port-yaml` scaffolded a doc, and `drift` + `audit-bind` **found it** at `<repo>/docs/tests/` — confirming `REPO_ROOT` resolves to the repo root. The whole B chain (bind → audit → run → drift) now works here with **no step-store**.

Fixes #21 · Part of ai-qa-step-graph STORY-011 / plan `dogkeeper886/ai-qa-step-graph#121`.

## Test plan
- [x] `qw-bind`/`qw-review-bind`/`qw-drift` reference `npm --prefix cicd/tests`; no `step-store` refs
- [x] `docs/tests/README.md` present
- [x] Run-phase wording is `npm test`
- [x] `drift`/`audit-bind` find a real doc at `<repo>/docs/tests` (REPO_ROOT proven)

Generated with [Claude Code](https://claude.com/claude-code)