### PR TITLE
Sweep test-framework-template refs + frame README as agent-workflows-runner

### DIFF
--- a/.claude/commands/dev-workflow/dw-test-design.md
+++ b/.claude/commands/dev-workflow/dw-test-design.md
@@ -33,7 +33,7 @@ Fits into the dev-workflow chain after /dw-implement and before /dw-create-pr.
         │   - Scan the project for existing test tooling:
         │
         │     Test Frameworks:
-        │     - cicd/tests/testcases/**/*.yml     → test-framework-template (YAML + dual-judge)
+        │     - cicd/tests/testcases/**/*.yml     → agent-workflows-runner (YAML + dual-judge)
         │     - tests/ + pytest.ini or conftest.py → pytest
         │     - __tests__/ or *.test.ts/js         → Jest
         │     - *.spec.ts/js                       → Jest / Vitest / Mocha
@@ -74,7 +74,7 @@ Fits into the dev-workflow chain after /dw-implement and before /dw-create-pr.
         │   │  - Commit test files to the issue branch
         │   │
         │   │  Examples by framework:
-        │   │  - test-framework-template → YAML in cicd/tests/testcases/{suite}/
+        │   │  - agent-workflows-runner → YAML in cicd/tests/testcases/{suite}/
         │   │  - pytest   → Python test files in tests/
         │   │  - Jest     → *.test.ts in __tests__/ or co-located
         │   │  - Go test  → *_test.go alongside source files
@@ -88,7 +88,7 @@ Fits into the dev-workflow chain after /dw-implement and before /dw-create-pr.
         │        - [ ] Step 2: description → expected result
         │      - Add a recommendation note:
         │        > This project has no automated test infrastructure.
-        │        > Consider adopting [test-framework-template](https://github.com/dogkeeper886/test-framework-template)
+        │        > Consider adopting [agent-workflows-runner](https://github.com/dogkeeper886/agent-workflows-runner)
         │        > for YAML-driven CI testing with dual-judge verification.
         │      - Ask the user: "Want me to create a follow-up issue for CI setup?"
         │        If yes → create issue labeled "enhancement" + "testing"
@@ -111,13 +111,13 @@ Fits into the dev-workflow chain after /dw-implement and before /dw-create-pr.
 
 ---
 
-## EXAMPLE 1: Project with test-framework-template
+## EXAMPLE 1: Project with agent-workflows-runner
 
     /dw-test-design 47
 
 **Agent detects cicd/tests/testcases/ with YAML files:**
 
-    Detected: test-framework-template (YAML + dual-judge)
+    Detected: agent-workflows-runner (YAML + dual-judge)
     CI: GitHub Actions (.github/workflows/test-pipeline.yml)
     Issue #47: enhancement → Type C (changed behavior)
 
@@ -167,7 +167,7 @@ Fits into the dev-workflow chain after /dw-implement and before /dw-create-pr.
     - [ ] Enter invalid email → shows validation error
 
     > This project has no automated test infrastructure.
-    > Consider adopting [test-framework-template](https://github.com/dogkeeper886/test-framework-template)
+    > Consider adopting [agent-workflows-runner](https://github.com/dogkeeper886/agent-workflows-runner)
     > for YAML-driven CI testing with dual-judge verification.
 
     Create follow-up issue for CI setup? [y/n]

--- a/.claude/skills/install/SKILL.md
+++ b/.claude/skills/install/SKILL.md
@@ -21,9 +21,9 @@ Install the test framework from the template source into the user's current work
 
 ### Step 1: Locate Template Source
 
-Input is the path to the test-framework-template repo:
+Input is the path to the agent-workflows-runner repo:
 - If provided: use it directly
-- If empty: check common locations (`~/src/test-framework-template`, `../test-framework-template`)
+- If empty: check common locations (`~/src/agent-workflows-runner`, `../agent-workflows-runner`)
 - If not found: ask the user for the path
 
 Read the template's `CLAUDE.md` to understand available components and the installation flow.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
-# Dual-Judge Test Framework Template
+# agent-workflows-runner
 
-A reusable, YAML-driven test framework for CI/CD pipelines. Fast and deterministic by default (the simple judge), with an opt-in LLM judge as a second opinion — reached through the Anthropic SDK, so any Anthropic-compatible endpoint (hosted or local) is just configuration.
+The test runner in the `agent-*` family — `agent-workflows` (the workflows), **`agent-workflows-runner`** (this repo, the runner they drive), and `agent-studio` (the flagship).
+
+A reusable, YAML-driven dual-judge test framework for CI/CD pipelines. Fast and deterministic by default (the simple judge), with an opt-in LLM judge as a second opinion — reached through the Anthropic SDK, so any Anthropic-compatible endpoint (hosted or local) is just configuration.
 
 ## Project Goal
 
-This test framework design template was extracted from production MCP server projects to provide a **reusable testing foundation** that can be adopted by any project.
+This test framework is the runner half of the `agent-*` family: the executable that `agent-workflows` drives. Extracted from production MCP server projects, it provides a **reusable testing foundation** any project can adopt.
 
 ### Why This Framework?
 
@@ -158,12 +160,12 @@ The LLM judge reads the criteria from YAML and evaluates whether the actual outp
 
 In your project directory, tell Claude Code:
 
-> Install the test framework from /path/to/test-framework-template
+> Install the test framework from /path/to/agent-workflows-runner
 
 Or use the slash command:
 
 ```
-/install /path/to/test-framework-template
+/install /path/to/agent-workflows-runner
 ```
 
 The agent will detect your project type (MCP server, Docker, etc.), ask configuration questions, and install only what you need with values pre-configured.
@@ -171,7 +173,7 @@ The agent will detect your project type (MCP server, Docker, etc.), ask configur
 ### Alternative: Manual Install
 
 ```bash
-cd /path/to/test-framework-template
+cd /path/to/agent-workflows-runner
 make install TARGET=/path/to/your/project NAME=your-project
 cd /path/to/your/project/cicd/tests
 npm install

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A reusable, YAML-driven dual-judge test framework for CI/CD pipelines. Fast and 
 
 ## Project Goal
 
-This test framework is the runner half of the `agent-*` family: the executable that `agent-workflows` drives. Extracted from production MCP server projects, it provides a **reusable testing foundation** any project can adopt.
+This test framework is the runner half of the `agent-*` family. Extracted from production MCP server projects, it provides a **reusable testing foundation** any project can adopt.
 
 ### Why This Framework?
 

--- a/docs/stories/STORY-002.md
+++ b/docs/stories/STORY-002.md
@@ -48,4 +48,4 @@ far the README reframe goes is left to the issue.
 
 - Created: 2026-06-11
 - Plan: #24
-- Issues: #25, #26, #27
+- Issues: ✅ #25 (repo rename, closed), #26 (refs + README — PR #28 open), #27 (#78 handoff, pending)


### PR DESCRIPTION
## Summary
- Reframe `README.md` as `agent-workflows-runner` in the `agent-*` family (H1 + intro + Project Goal), keeping the "dual-judge test framework" descriptor; update 3 install-path examples.
- Repoint 6 refs in `.claude/commands/dev-workflow/dw-test-design.md` (4 detection/display labels + 2 `github.com/dogkeeper886/...` URLs).
- Update `.claude/skills/install/SKILL.md` (prose ref + 2 common-location path hints).

Left as-is per plan #24: `Makefile` labels, `cicd/tests/package.json` "name", and the `docs/stories/STORY-001.md` historical line.

Reviewed before this PR: `dw-review-implement` (PASS), `reviewing-phrasing` (one tightening applied), `reviewing-typography` (PASS), `reviewing-artifacts` (PASS).

Fixes #26
Part of STORY-002 (#24)

## Test plan
- [ ] `grep -rn test-framework-template` returns only the `docs/stories/` lines (STORY-001 historical + STORY-002 narrating the rename) — no refs in README or tooling
- [ ] README top section reads as `agent-workflows-runner` in the family, descriptor preserved
- [ ] The two repointed GitHub URLs in `dw-test-design.md` resolve

Generated with [Claude Code](https://claude.com/claude-code)