### PR TITLE
CI: keyless agent judge on a self-hosted runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
   #   name: "Test: Auth"
   #   needs: build
   #   uses: ./.github/workflows/test-run.yml
-  #   secrets: inherit          # passes CLAUDE_CODE_OAUTH_TOKEN through for dual mode
+  #   secrets: inherit          # only if your test steps need project secrets (the judge needs none)
   #   with:
   #     tag: auth
   #     judge_mode: ${{ inputs.judge_mode }}
@@ -34,6 +34,6 @@ jobs:
     name: "Test: All"
     needs: build
     uses: ./.github/workflows/test-run.yml
-    secrets: inherit            # passes CLAUDE_CODE_OAUTH_TOKEN through for dual mode
+    secrets: inherit            # only if your test steps need project secrets (the judge needs none)
     with:
       judge_mode: ${{ inputs.judge_mode }}

--- a/.github/workflows/test-feature-example.yml
+++ b/.github/workflows/test-feature-example.yml
@@ -30,7 +30,7 @@ on:
 jobs:
   test:
     uses: ./.github/workflows/test-run.yml
-    secrets: inherit                    # passes CLAUDE_CODE_OAUTH_TOKEN through for dual mode
+    secrets: inherit                    # only if your test steps need project secrets (the judge needs none)
     with:
       tag: "example"                    # <-- Change this to your feature tag
       judge_mode: ${{ inputs.judge_mode }}

--- a/.github/workflows/test-run.yml
+++ b/.github/workflows/test-run.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   test:
     name: Run Tests
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     outputs:
       result: ${{ steps.run-tests.outcome }}
 
@@ -49,13 +49,12 @@ jobs:
       - name: Run tests
         id: run-tests
         env:
-          # Simple by default; dual opts in the agent judge, which runs keyless on a
-          # Claude Code subscription via CLAUDE_CODE_OAUTH_TOKEN — no Console API key.
-          # JUDGE_AGENT (repo variable) swaps the ACP agent/model; empty uses the
-          # bundled Claude ACP agent. Model + auth live in the agent, not here.
+          # Simple by default; dual opts in the agent judge, which runs keyless via the
+          # runner's own Claude Code login (~/.claude on the self-hosted runner) — no
+          # Console API key, no secret. JUDGE_AGENT (repo variable) swaps the ACP
+          # agent/model; empty uses the bundled Claude ACP agent. Auth lives in the agent.
           JUDGE_MODE: ${{ inputs.judge_mode }}
           JUDGE_AGENT: ${{ vars.JUDGE_AGENT }}
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         run: |
           cd cicd/tests
 

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -40,7 +40,7 @@ on:
 jobs:
   test:
     name: Run ${{ inputs.suite }} Tests
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     outputs:
       result: ${{ steps.run-tests.outcome }}
 
@@ -59,13 +59,12 @@ jobs:
       - name: Run tests
         id: run-tests
         env:
-          # Simple by default; dual opts in the agent judge, which runs keyless on a
-          # Claude Code subscription via CLAUDE_CODE_OAUTH_TOKEN — no Console API key.
-          # JUDGE_AGENT (repo variable) swaps the ACP agent/model; empty uses the
-          # bundled Claude ACP agent.
+          # Simple by default; dual opts in the agent judge, which runs keyless via the
+          # runner's own Claude Code login (~/.claude on the self-hosted runner) — no
+          # Console API key, no secret. JUDGE_AGENT (repo variable) swaps the ACP
+          # agent/model; empty uses the bundled Claude ACP agent.
           JUDGE_MODE: ${{ inputs.judge_mode }}
           JUDGE_AGENT: ${{ vars.JUDGE_AGENT }}
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         run: |
           cd cicd/tests
 

--- a/docs/stories/STORY-004.md
+++ b/docs/stories/STORY-004.md
@@ -71,6 +71,6 @@ endpoint. The gap is purely auth: there's no keyless option for the subscription
 - Created: 2026-06-13
 - Issues: #35
 - Plan: #36
-- Tasks: #37, #38, #39, #40
-- PRs: #41 (#37 — open)
+- Tasks: #37 ✓, #38, #39 ✓, #40
+- PRs: #41 (#37 + #39 — merged 2026-06-13)
 - Tests: none


### PR DESCRIPTION
## Summary
Follow-up to #39. The runner is self-hosted and already logged into Claude Code, so the agent judge needs **no `CLAUDE_CODE_OAUTH_TOKEN` secret** — it authenticates through the runner's `~/.claude`.

- `runs-on: ubuntu-latest` → `self-hosted` (`build.yml`, `test-run.yml`, `test-suite.yml`)
- Drop the `CLAUDE_CODE_OAUTH_TOKEN` env line from the test jobs; auth lives entirely in `~/.claude`
- Retire the token-justified `secrets: inherit` comments (kept the line only as a hook for project test secrets)
- Records #37 + #39 merged on STORY-004

## Why no secret is needed
Verified locally: with `ANTHROPIC_API_KEY` unset **and** `CLAUDE_CODE_OAUTH_TOKEN=""` (what an unset GitHub secret renders to), the agent judge still authenticates via `~/.claude` (`isAvailable()` = true). On a self-hosted runner logged into Claude Code, `dual` mode just works.

## Test plan
- [x] No `CLAUDE_CODE_OAUTH_TOKEN`/`ANTHROPIC_API_KEY`/`LLM_JUDGE_*` references remain in `.github/workflows/`
- [x] All six workflow YAMLs parse
- [ ] Reviewer: confirm the self-hosted runner is logged into Claude Code (`~/.claude` present) before running `dual`

Part of STORY-004

🤖 Generated with [Claude Code](https://claude.com/claude-code)