### PR TITLE
Land the customization seam + sibling workflow rules (#49)

### DIFF
--- a/.claude/rules/dev-workflow.md
+++ b/.claude/rules/dev-workflow.md
@@ -71,3 +71,11 @@ review passes plus a plan issue on a typo is ritual, not rigor (see CLAUDE.md §
 - **GitHub issues** already hold the work; the plan is one too (the parent), so the
   approach, its review, and its history live where the tasks do — no separate plan store.
 - **CI** is the project's existing checks + human review — the merge gate, not a new pipeline.
+
+## Project-specific values
+
+Story paths, the `STORY-XXX` id scheme, label names + colours, the `[STORY-XXX]` /
+`Part of #<plan>` linking patterns, the `issue-<N>-<slug>` branch name, and the merge
+strategy are **not** owned by the `dw-*` commands — they resolve from
+`.claude/rules/project-profile.md`. The values a command shows are the defaults; change
+them in the profile, not the command.

--- a/.claude/rules/doc-workflow.md
+++ b/.claude/rules/doc-workflow.md
@@ -1,0 +1,51 @@
+---
+paths:
+  - ".claude/commands/doc-workflow/**/*.md"
+---
+
+# doc-workflow
+
+A sibling to `dev-workflow` and `qa-workflow`. Where dev-workflow turns a need into shipped
+code, doc-workflow turns a **codebase into its README** — a newcomer-facing document grounded
+in current best practice, leading with the few ideas worth a diagram, and true to the code.
+
+## The flow
+
+```
+   a repo  ──or──  "write the README for X"   (on request)
+        │
+        ▼
+   doc-gen-readme ───► doc-review-readme ───► [human reviews] ───► PR
+        │                    │
+        │                    └─ reuses reviewing-phrasing + reviewing-typography,
+        │                       then verifies every claim against the code
+        ▼
+   README.md (+ docs/diagrams/* when diagrams help)
+```
+
+`doc-gen-readme` opens with a mandatory **WebSearch** step so the structure tracks current
+convention rather than a frozen template. Diagrams are optional: when used, the SVG is the
+source of truth and the embedded PNG is rendered reproducibly.
+
+## Producer → review pairing
+
+| Producer | Review | Covers |
+|----------|--------|--------|
+| `doc-gen-readme` | `doc-review-readme` | reads + looks right (via the reviewing skills), true to the code, delivers for a newcomer |
+
+No producer ships without a review covering its output.
+
+## What this owns — and what it reuses
+
+- **Owns:** the README authoring flow + the accuracy gate (claims verified against the code,
+  links resolve, diagrams match reality). Self-contained — markdown + the repo.
+- **Reuses:** the human-read doc review — `reviewing-phrasing` (the words) and
+  `reviewing-typography` (the look). `doc-review-readme` calls them rather than re-judging
+  prose itself.
+
+## Project-specific values
+
+The images dir, the diagram policy (SVG source → PNG), and the README output path are
+**not** owned by the `doc-*` commands — they resolve from
+`.claude/rules/project-profile.md`. The values a command shows are the defaults; change
+them in the profile, not the command.

--- a/.claude/rules/project-profile.md
+++ b/.claude/rules/project-profile.md
@@ -1,0 +1,108 @@
+---
+paths:
+  - ".claude/commands/**/*.md"
+  - ".claude/skills/**/*.md"
+---
+
+# project-profile
+
+The one place this project declares its specifics. The shipped commands and skills state
+their *intent* and resolve any project-specific value — a path, an ID scheme, a label, an
+integration, a format, an audience — **from this file**, instead of hardcoding it.
+Customize a workflow by editing this file, not the units.
+
+**How a unit uses it.** Where a command or skill would otherwise bake in a value, it
+points at the matching section here (e.g. "create the *plan* label — see project-profile →
+Labels"). The values below are this runner's real values — the agent-workflows
+test-framework runner, the binding + run + drift layer that upstream's `qa-workflow` hands
+off to. Change a line here and every unit follows.
+
+**What belongs here vs. not.** This file is for **declarative** customization — a value or
+a list. A whole **procedure** (how this runner binds a doc to its YAML, runs the suite, and
+audits drift) is *not* a value; it lives in this repo's own commands (`qw-bind`,
+`qw-review-bind`, `qw-drift`) and the `cicd/` runner, never crammed into a general unit.
+Lists → here; procedures → a project-owned command. This is the rules files' "what this
+owns vs. what it hands off" boundary, made concrete.
+
+---
+
+## Paths
+
+- stories dir: `docs/stories/`
+- tests dir: `docs/tests/`
+- images dir: `docs/diagrams/` (SVG source) → `docs/diagrams/png/` (rendered PNG)
+- story format contract: `docs/stories/README.md`
+- test format contract: `docs/tests/README.md`
+
+## ID schemes
+
+- story id: `STORY-XXX` (zero-padded sequential, e.g. `STORY-001`)
+- scenario id: `TS-NN`
+- case id: `TC-NN`
+- executable (cicd YAML) id: `TC-<SUITE>-XXX` — `TC-BUILD-XXX`, `TC-INTEGRATION-XXX`, `TC-E2E-XXX`,
+  one per suite dir under `cicd/tests/testcases/<suite>/`
+- title prefixes: `[STORY-XXX] Plan` · `[STORY-XXX] Test Plan` · `[STORY-XXX] <task>`
+
+## Labels
+
+Names the workflow uses; colours where the workflow pins one (`#hex`), otherwise the
+project's choice.
+
+- plan: `plan` (`#5319e7`)
+- test plan: `test-plan` (`#006b75`)
+- priority: `priority:high` · `priority:medium` · `priority:low`
+- type: `feature` · `enhancement` · `bug` · `docs`
+- status: `status:in-progress` · `status:needs-review` · `status:blocked`
+
+## Linking & branch
+
+- story back-reference (in titles/bodies): `[STORY-XXX]`
+- plan back-reference (task → plan): `Part of #<plan>`
+- issue closure (PR → issue): `Fixes #N` / `Closes #N`
+- feature branch name: `issue-<N>-<slug>`
+
+## Git
+
+- default branch: *derive it* (`gh repo view --json defaultBranchRef -q .defaultBranchRef.name`), don't assume `main`
+- merge strategy: `--merge` (preserve history; switch to `--squash` only if the project requires)
+
+## Front-matter & format contract (test docs)
+
+- test-doc filename: `TS-NN-<slug>.md` in the tests dir
+- front-matter fields: `id, title, namespace, story, story_hash, plan, status`
+- namespace: `test-framework`
+- story hash: `sha256` of the story file (`sha256sum`)
+- default status: `green` (drift states `stale` | `unbound`, maintained by `qw-drift`)
+
+## Docs & diagrams
+
+- README output: `README.md`
+- diagram policy: SVG source committed under `docs/diagrams/`, rendered to PNG under
+  `docs/diagrams/png/` via `make diagrams` (no Mermaid / inline diagram blocks)
+- images dir: `docs/diagrams/` (also under Paths)
+
+## Review semantics
+
+- canonical format (source of truth): `markdown`
+- live integrations: `GitHub` — tools the project genuinely uses; coupling to one listed
+  here is correct, not drift. (A downstream adds its own, e.g. Jira, Confluence, TestLink.)
+- deliverable (triggers a paired review): a unit that *produces or changes* an output —
+  by name (`create-`/`sync-`/`publish-`/`draft-`/`init-`) or as a producing gerund skill
+  (`planning-…`, `drafting-…`)
+- audience (human-read docs): engineers and newcomers
+
+## This project's binding + run + drift layer (NOT deferred)
+
+Upstream's `qa-workflow` hands binding and running off to "the project's own layer." **This
+repo IS that layer.** Binding, audit, and drift are owned here, not deferred:
+
+- bind a case to its executable: `qw-bind` → sets each TC's `Script:` to a
+  `cicd/tests/testcases/**/*.yml`
+- audit a binding: `qw-review-bind` → `npm --prefix cicd/tests run audit-bind` (the `Script:`
+  resolves and the doc's step count matches the YAML's, else `unbound`)
+- run the suite (the `qw-run` phase — a phase, not a slash command): `npm test`
+- watch for drift: `qw-drift` → `npm --prefix cicd/tests run drift` (`stale` when `story_hash`
+  no longer matches the story)
+- scaffold a doc from a YAML: `npm --prefix cicd/tests run port-yaml -- <yaml>`
+- reuse index: **none** — reuse is the optional enhancement upstream describes; it is not
+  present here.

--- a/.claude/rules/qa-workflow.md
+++ b/.claude/rules/qa-workflow.md
@@ -1,0 +1,57 @@
+---
+paths:
+  - ".claude/commands/qa-workflow/**/*.md"
+---
+
+# qa-workflow
+
+A sibling to `dev-workflow`. Where dev-workflow turns a need into shipped code, qa-workflow
+turns a story into **trustworthy test docs** — readable markdown in `docs/tests/`, authored
+from a reviewed test plan. This repo owns the **authoring** half (markdown + GitHub); binding
+those docs to a runner and running them is the project's own layer.
+
+## The flow
+
+```
+   docs/stories/STORY-XXX.md   ──or──  "write a test for X"   (on request)
+            │
+            ▼
+   qw-plan ───────► qw-review-plan      what to test — scenarios persisted as the
+            │                            [STORY-XXX] Test Plan issue
+            ▼
+   qw-cases ──────► qw-review-cases     write docs/tests/TS-*.md (the format contract)
+            │
+            ▼
+   → hand off to the project's binding + run layer
+```
+
+## The test-plan issue
+
+`qw-plan`'s scenarios persist as a **GitHub issue**, titled `[STORY-XXX] Test Plan`, labelled
+`test-plan` (distinct from dev's `[STORY-XXX] Plan`). `qw-review-plan` reviews it; `qw-cases`
+reads it and records the issue number in each `TS-*.md` `plan:` field.
+
+## Producer → review pairing
+
+| Producer | Review | Covers |
+|----------|--------|--------|
+| `qw-plan`  | `qw-review-plan`  | does the plan cover the story? |
+| `qw-cases` | `qw-review-cases` | each doc: one job, observable, traces back |
+
+No producer ships without a review covering its output.
+
+## What this owns — and what it hands off
+
+- **Owns:** the authoring flow + the `docs/tests/` test-doc format (the contract). Self-contained
+  — markdown + GitHub only.
+- **Hands off:** binding each case to an executable and running it is the **project's binding +
+  run layer**. Reusing vetted steps (a search index) is an **optional** project enhancement.
+
+The format a test doc must follow is `docs/tests/README.md`.
+
+## Project-specific values
+
+The `docs/tests/` path, the `test-plan` label + colour, the `TS-`/`TC-` id schemes, the
+test-doc front-matter fields, the hash algorithm, and the default status are **not** owned
+by the `qw-*` commands — they resolve from `.claude/rules/project-profile.md`. The values
+a command shows are the defaults; change them in the profile, not the command.

--- a/docs/stories/README.md
+++ b/docs/stories/README.md
@@ -1,0 +1,91 @@
+# `docs/stories/` — the story format
+
+Each story is a **readable markdown document** that lives here. It states a **need** — a
+goal, not a spec — in the user's terms. The markdown is the *canonical* record of *why* a
+piece of work exists; it is the stable anchor the plan and task issues trace back to.
+`dw-story` writes these; `dw-review-story` reviews them.
+
+The **how** — the agreed approach and the work itself — lives in the **plan issue** and the
+**task issues** on GitHub, **not here**. A story says what's needed and what success looks
+like; it does not freeze a design. Keeping the *how* out of the story is what lets the
+approach evolve on the issues without rewriting the need.
+
+## One file = one story
+
+```
+docs/stories/
+  STORY-001.md   # one story: the need + success, nothing about the build
+  STORY-002.md
+```
+
+- File + id follow the project's `STORY-XXX` convention — `STORY-NNN.md`, no slug (see `.claude/rules/project-profile.md`).
+- A story is **plain markdown — no front-matter.** It opens with `# STORY-NNN: <Title>`.
+
+## Sections
+
+In order, every story carries:
+
+```markdown
+# STORY-NNN: <specific title>
+
+## User Story
+As <role>, I want <goal>, so that <benefit>.
+
+## The Need
+<the problem behind the request, in the user's terms — the why, not the how>
+
+## Success Looks Like
+- <an outcome someone could observe once this is delivered>
+
+## Open Questions
+- <what's genuinely unresolved — or "none known"; deferred to the plan/issues>
+
+## Status
+- Created: <date>
+```
+
+- **User Story** — a real role, action, and a benefit that isn't just the action restated.
+- **The Need** — the problem and why it matters, in the reader's terms. No files, APIs, or
+  step-by-step build detail.
+- **Success Looks Like** — observable, user-facing outcomes — not implementation steps.
+- **Open Questions** — the uncertain *how*, deferred to the plan/issues. Empty-because-skipped
+  is a finding, not a pass.
+- **Status** — the record below.
+
+## Status conventions
+
+The Status block grows as the work moves, linking the story to its GitHub artifacts:
+
+```markdown
+## Status
+
+- **Completed: <date>** — <one line on what shipped> (PRs #<n>, #<n>).
+- Created: <date>
+- Plan: #<plan-issue>
+- Issues: ✅ #<n> (PR #<n>), ✅ #<n>, …
+```
+
+- `Created:` on every story; the **bold `Completed:`** line is added (first) once delivered.
+- `Plan:` is the `[STORY-XXX] Plan` issue (`dw-plan`); `Issues:` are the tasks (`dw-tasks`),
+  ✅ when closed.
+
+## Goal, not spec
+
+`dw-review-story` gates exactly this: the story is **complete** (every section present and
+substantive) and stays a **goal document** — no leaked implementation, success written as
+outcomes, the technical *how* left to the issues. A story decidable by someone who won't
+build it has passed.
+
+## Traceability
+
+- **story → plan/tasks:** the `Status` block's `Plan:` and `Issues:` lines.
+- **plan/task → story:** the issue's `[STORY-XXX]` title prefix and `Part of` link.
+
+No hand-maintained index — the links live in the files and the issues, and resolve by
+path / `gh`.
+
+## Beyond the story (the plan + issues)
+
+The approach, the task breakdown, and the build history are the **plan issue** and **task
+issues'** concern, not this format's. The story records the need; the issues carry the how
+(see `.claude/rules/dev-workflow.md`).

--- a/docs/stories/STORY-005.md
+++ b/docs/stories/STORY-005.md
@@ -65,4 +65,5 @@ running rather than deferring them.
 
 - Created: 2026-06-21
 - Plan: #48
-- Issues: #49, #50, #51, #52
+- Issues: #49 (PR #53, open), #50, #51, #52
+- PRs: #53 (#49) — open

--- a/docs/stories/STORY-005.md
+++ b/docs/stories/STORY-005.md
@@ -1,0 +1,68 @@
+# STORY-005: Re-base the runner onto the upstream template's customization seam
+
+## User Story
+
+As someone porting this runner into my own project,
+I want the generalized workflow tooling to stay generic and all the project-specific
+values to live in one declared place,
+So that I customize a single profile instead of editing — and later having to re-merge —
+the shared commands, skills, and rules.
+
+## The Need
+
+The upstream sibling `ai-qa-workflow` was redesigned into a reusable **template**: it
+introduced a customization seam, `.claude/rules/project-profile.md`, where a project
+declares *all* its specifics — paths, ID schemes, labels, branch and merge conventions,
+format contracts, audience, live integrations. The generalized commands, skills, and
+rules then **resolve** those values from the profile instead of hardcoding them. You
+customize the profile; you never touch the generic units.
+
+This runner forked **before** that redesign. It never got the seam, so its
+project-specific values are scattered through the generic units, and some of its
+generalized commands carry pre-template text that has since gone stale — including
+references to a `step-store` / `make query` layer this runner doesn't even have. The
+result: the runner can't cleanly track upstream's improvements, and anyone adopting it
+has to edit the generic parts to make it theirs, which is exactly what the template
+redesign set out to end.
+
+The runner also has its own real identity that the upstream doesn't: a `cicd/` test
+runner and a binding / run / drift layer (`qw-bind`, `qw-review-bind`, `qw-drift`).
+Upstream's qa-workflow *defers* that layer to "the project's own layer" — this runner
+*is* that layer. So this is not a blind copy of upstream: the generic base should come
+from upstream, but the runner's own commands, skills, and rules must be preserved as a
+clearly separated layer, and the profile must declare that this project owns binding and
+running rather than deferring them.
+
+## Success Looks Like
+
+- A newcomer customizing the runner edits **one** file — the profile — to point it at
+  their paths, IDs, labels, and conventions, and never has to modify a generalized
+  command, skill, or rule.
+- The generalized tooling matches upstream closely enough that future upstream
+  improvements can be pulled in by re-syncing, not hand-reconciling.
+- The runner's own layer — the `cicd/` runner, its binding/run/drift commands, its
+  runner-specific skills and rules — is intact and visibly separate from the generic
+  base, and the profile names that layer as something this project owns, not defers.
+- Stale references to tooling the runner doesn't have (the `step-store` / `make query` /
+  `make up` layer) are gone; the docs point at the runner's real commands.
+- The docs read true: the test-doc format contract still describes the runner's actual
+  binding/drift behavior, and a reader can find the one place to customize.
+
+## Open Questions
+
+- How much of upstream is a byte-identical adoption versus a runner-aware merge, and
+  which files fall in each bucket? (Worked out on the plan.)
+- Adopting upstream's qa-workflow means test plans become persisted GitHub issues rather
+  than chat-only — is that behavior change wanted here, given GitHub is a live
+  integration for this repo?
+- How should the test-doc format contract reconcile upstream's "binding is out of scope"
+  stance with the fact that this runner owns binding/run/drift?
+- Which runner-specific lines in the shared units (the `dw-test-design` review pairing,
+  the `code-review` / `/review` gate guidance in CLAUDE.md) must survive the merge rather
+  than be overwritten by the upstream version?
+
+## Status
+
+- Created: 2026-06-21
+- Plan: #48
+- Issues: #49, #50, #51, #52


### PR DESCRIPTION
## Summary
- Add `.claude/rules/project-profile.md` — the one declarative place this runner's project-specific values live (paths, IDs, labels, branch/merge, test-doc front-matter, diagram policy), with a **"binding + run + drift layer (NOT deferred)"** section: upstream's qa-workflow hands that layer off to "the project's own layer", and this repo *is* that layer (`qw-bind`/`qw-review-bind`/`qw-drift`, `npm test`, `npm --prefix cicd/tests run audit-bind|drift|port-yaml`).
- Adopt upstream's `qa-workflow.md` (verbatim) and `doc-workflow.md` rules (the latter adapts the illustrative `docs/images/` path to this repo's `docs/diagrams/` policy).
- Merge `dev-workflow.md` surgically — append only the missing **Project-specific values** section, preserving the runner's richer content (the `dw-test-design` pairing row, the `qa-workflow` cross-links, the CLAUDE.md §5 reference).
- Add `docs/stories/README.md` (story-format contract, adopted verbatim) so the profile's declared contract path resolves — pulled forward from #52 after the code-review flagged the dangling reference.

All declared profile values were verified against the repo (executable id schemes, front-matter fields, binding commands, diagram paths). The `cicd/` runner is untouched.

Fixes #49
Part of STORY-005 · plan #48

## Test plan
- [ ] `ls .claude/rules/` shows `project-profile.md`, `qa-workflow.md`, `doc-workflow.md`, `dev-workflow.md` + the preserved `test-yaml-format.md`, `workflow-patterns.md`
- [ ] `diff` `qa-workflow.md` against upstream → identical; `doc-workflow.md` differs only by the `docs/diagrams/` line
- [ ] `grep -rn "docs/images" .claude/rules/` → empty
- [ ] `dev-workflow.md` still carries the `dw-test-design` row and resolves `project-profile.md`
- [ ] profile front-matter field list matches `docs/tests/README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)