### PR TITLE
De-bake the generalized qw-* commands to upstream form (#50)

### DIFF
--- a/.claude/commands/qa-workflow/qw-cases.md
+++ b/.claude/commands/qa-workflow/qw-cases.md
@@ -2,9 +2,9 @@
 
 ```
 Turn a reviewed test plan into readable test docs in docs/tests/ — reusing vetted
-steps from the store instead of re-inventing them.
+steps where a reuse index is available, instead of re-inventing them.
 
-Target: the scenarios approved by /qw-review-plan for a STORY-XXX.
+Target: the reviewed `[STORY-XXX] Test Plan` issue from `/qw-review-plan` (its scenarios).
 
 ## PURPOSE
 
@@ -15,8 +15,8 @@ Action / Expected Result rows.
 
 Fits in the qa-workflow:
 
-    qw-plan → qw-review-plan → qw-cases → qw-review-cases → qw-bind → qw-run
-    (qw-run = `make up` + the cicd runner — a phase, not a slash command)
+    qw-plan → qw-review-plan → qw-cases → qw-review-cases   (the authoring half)
+    → hand off to the project's binding + run layer
 
 ---
 
@@ -24,32 +24,39 @@ Fits in the qa-workflow:
 
     /qw-cases STORY-003
         │
-        ├─► Step 1: One file per scenario
+        ├─► Step 1: Read the test-plan issue
+        │   - Find it (`test-plan` is qa's own label — distinct from dev's `plan`):
+        │       gh issue list --search "[STORY-XXX] Test Plan" --label test-plan --state all
+        │     Read its scenarios; note its number <plan>. (No plan issue → the scenarios
+        │     came from /qw-plan in chat; <plan> is absent.)
+        │
+        ├─► Step 2: One file per scenario
         │   - Create docs/tests/TS-NN-<slug>.md with front-matter:
         │       id, title, namespace, story (+ story_hash = sha256 of the story file),
+        │       plan: <plan> (the test-plan issue number — omit when there is none),
         │       issue, status: green
         │   - (Format and field meanings: docs/tests/README.md.)
         │
-        ├─► Step 2: Write each case (TC) — reuse before re-inventing (dogfood the store)
-        │   - For each step you are about to write, ask the store first:
-        │       make query Q="<the action you mean>"
-        │     If a vetted step comes back close, phrase yours to match it — same
-        │     meaning, same good expected result — instead of coining a new one.
+        ├─► Step 3: Write each case (TC) — reuse before re-inventing
+        │   - If the project has a reuse index, query it before writing: is the case's
+        │     objective already covered? is there a vetted step for the action you mean?
+        │     Reuse or extend a close match instead of coining a near-duplicate (optional).
         │   - Fill the Steps table: each row one Action + its Expected Result.
-        │
-        ├─► Step 3: Index + bind
-        │   - Load the new docs into the store:  npm --prefix step-store run load-tests
-        │   - Bind each case to its executable:  /qw-bind  (then /qw-review-bind)
         │
         └─► Step 4: Hand off
             - Run `/qw-review-cases` to gate the docs.
+            - Reviewed docs then hand to the project's binding + run layer — bind each case
+              to its executable and run it. (If a reuse index exists, the new docs get
+              indexed there.)
 
 ---
 
 ## API Notes
 
-- Reuse is the point of the store: `search_step` (via `make query`) makes a vetted
-  step findable so coverage converges instead of duplicating.
+- Reuse is optional: if the project has a reuse index, query it for a vetted case or
+  step before authoring a near-duplicate, so coverage converges instead of duplicating.
 - `story_hash`: `sha256sum docs/stories/STORY-XXX.md`.
+- `plan`: the `[STORY-XXX] Test Plan` issue number — the scenario source and the trace
+  back (see docs/tests/README.md). Absent for ad-hoc tests written without a plan.
 - Producer paired with `/qw-review-cases`.
 ```

--- a/.claude/commands/qa-workflow/qw-plan.md
+++ b/.claude/commands/qa-workflow/qw-plan.md
@@ -9,13 +9,15 @@ Target: a STORY-XXX, or an ad-hoc request ("write a test for X").
 ## PURPOSE
 
 The front of the qa-workflow — the test analogue of reading a story before
-implementing. It produces a short, reviewable list of **scenarios** (each a TS-to-be)
-that together cover the need, so `qw-cases` has a scoped plan to write against.
+implementing. It produces a short list of **scenarios** (each a TS-to-be) that together
+cover the need, and **persists them as a `[STORY-XXX] Test Plan` GitHub issue** so the plan
+survives the session and `qw-review-plan` reviews a real artifact (not a chat message);
+`qw-cases` then writes against it. See `.claude/rules/qa-workflow.md`.
 
 Fits in the qa-workflow:
 
-    qw-plan → qw-review-plan → qw-cases → qw-review-cases → qw-bind → qw-run
-    (qw-run = `make up` + the cicd runner — a phase, not a slash command)
+    qw-plan → qw-review-plan → qw-cases → qw-review-cases   (the authoring half)
+    → hand off to the project's binding + run layer
 
 ---
 
@@ -27,27 +29,54 @@ Fits in the qa-workflow:
         │   - If a STORY-XXX: read docs/stories/STORY-XXX.md (the need + "Success Looks Like").
         │   - If an on-request target: restate what behaviour is to be verified.
         │
-        ├─► Step 2: Check what already exists (dogfood the store)
-        │   - Search the step-store for steps/cases already covering this:
-        │       make query Q="<the behaviour>"
-        │     so the plan reuses vetted coverage instead of duplicating it.
+        ├─► Step 2: Check what already exists
         │   - List the docs/tests/ scenarios already linked to this story:
         │       grep -l 'story: STORY-XXX' docs/tests/
+        │   - If the project has a reuse index, query it for cases already covering this
+        │     behaviour, so the plan reuses vetted coverage instead of duplicating it (optional).
+        │   - Check for an existing test-plan issue (extend it, don't duplicate):
+        │       gh issue list --search "[STORY-XXX] Test Plan" --label test-plan --state all
+        │     (`test-plan` is qa's own label — distinct from dev's `plan`)
         │
         ├─► Step 3: Propose scenarios
         │   - Break the need into scenarios (TS-to-be), each:
         │     • one coherent slice of behaviour, • independently runnable,
-        │     • mappable to one or more cicd executables.
+        │     • mappable to one or more of the project's executables (bound later, project layer).
         │   - For each, name the cases (TC-to-be) it will hold, at a sentence each.
         │
-        └─► Step 4: Hand off
-            - Present the scenario list for `/qw-review-plan`, then `/qw-cases`.
+        ├─► Step 4: Open the test-plan issue
+        │   - Ensure the label (idempotent):
+        │       gh label create "test-plan" --color "006b75" --description "The qa test plan for a story (what to test)" --force
+        │   - Write the scenarios into a GitHub issue so they outlive the session
+        │     (the template below). Title: [STORY-XXX] Test Plan
+        │     (ad-hoc target → "Test Plan: <subject>", no story prefix). Label: test-plan.
+        │       gh issue create --label "test-plan" --title "[STORY-XXX] Test Plan" --body "…"
+        │
+        └─► Step 5: Hand off — stop for review
+            - Show the test-plan issue URL for `/qw-review-plan`, then `/qw-cases`.
+            - STOP. Do NOT write TS docs — that is `/qw-cases`.
+
+---
+
+## TEST-PLAN ISSUE BODY
+
+    ## Scenarios
+    ### TS-01 (to-be): <scenario title>
+    - Objective: <the slice of behaviour it verifies>
+    - Cases: TC-01 <one line>, TC-02 <one line>
+
+    ### TS-02 (to-be): …
+
+    Part of STORY-XXX
 
 ---
 
 ## API Notes
 
 - A scenario here is a *plan item*, not yet a file — `qw-cases` writes the doc.
+- The scenarios persist as a `[STORY-XXX] Test Plan` issue (label `test-plan`; ad-hoc →
+  `Test Plan: <subject>`) — the same plan-as-issue form `dev-workflow` uses, with its own
+  `test-plan` label so it never collides with dev's `[STORY-XXX] Plan` (label `plan`).
 - The story is the goal; keep the plan to coverage, not step detail.
-- Producer paired with `/qw-review-plan`.
+- Producer paired with `/qw-review-plan`, which reviews the issue.
 ```

--- a/.claude/commands/qa-workflow/qw-review-cases.md
+++ b/.claude/commands/qa-workflow/qw-review-cases.md
@@ -13,8 +13,8 @@ gates the written docs for quality and traceability.
 
 Fits in the qa-workflow:
 
-    qw-plan → qw-review-plan → qw-cases → qw-review-cases → qw-bind → qw-run
-    (qw-run = `make up` + the cicd runner — a phase, not a slash command)
+    qw-plan → qw-review-plan → qw-cases → qw-review-cases   (the authoring half)
+    → hand off to the project's binding + run layer
 
 ---
 
@@ -30,19 +30,19 @@ Fits in the qa-workflow:
         │   - [ ] Conforms to the format contract (docs/tests/README.md).
         │
         ├─► Step 2: Traceability
-        │   - [ ] story → doc → (script, via qw-bind) resolves both ways.
+        │   - [ ] story → doc resolves both ways (→ executable once bound, project layer).
         │   - [ ] No duplicate of an existing scenario for the same story.
         │
         └─► Step 3: Decision
-            - PASS: docs do their job and trace back → proceed to `/qw-bind` (if not
-              yet bound), then run it (`make up` + the cicd runner).
+            - PASS: docs do their job and trace back → hand off to the project's binding
+              + run layer (bind each case to its executable, then run it).
             - REVISE: fix the named doc — smallest change first — and re-check.
 
 ---
 
 ## API Notes
 
-- This reviews the *doc* (intent); `/qw-review-bind` reviews the doc↔script binding.
+- This reviews the *doc* (intent); the doc↔script binding is reviewed in the project's binding + run layer, not here.
 - Published-deliverable phrasing/typography is out of scope here.
 - Review paired with the producer `/qw-cases`.
 ```

--- a/.claude/commands/qa-workflow/qw-review-plan.md
+++ b/.claude/commands/qa-workflow/qw-review-plan.md
@@ -4,18 +4,18 @@
 Check the proposed scenarios cover the story — and stay coverage, not a frozen
 step-by-step spec.
 
-Target: the scenario list from /qw-plan for a STORY-XXX — as proposed in the
-conversation, or as already realized in docs/tests/ when reviewing after the fact.
+Target: the `[STORY-XXX] Test Plan` issue written by `/qw-plan` (label `test-plan`).
 
 ## PURPOSE
 
-The paired review for `/qw-plan`. Gates the plan before `qw-cases` writes any docs,
-so coverage gaps are caught cheaply.
+The paired review for `/qw-plan`. Gates the persisted **test-plan issue** before
+`qw-cases` writes any docs, so coverage gaps are caught cheaply. See
+`.claude/rules/qa-workflow.md`.
 
 Fits in the qa-workflow:
 
-    qw-plan → qw-review-plan → qw-cases → qw-review-cases → qw-bind → qw-run
-    (qw-run = `make up` + the cicd runner — a phase, not a slash command)
+    qw-plan → qw-review-plan → qw-cases → qw-review-cases   (the authoring half)
+    → hand off to the project's binding + run layer
 
 ---
 
@@ -23,24 +23,32 @@ Fits in the qa-workflow:
 
     /qw-review-plan STORY-003
         │
-        ├─► Step 1: Coverage vs the story
+        ├─► Step 1: Read the test-plan issue
+        │   - Find it (`test-plan` is qa's own label — distinct from dev's `plan`):
+        │       gh issue list --search "[STORY-XXX] Test Plan" --label test-plan --state all
+        │     (ad-hoc target: search "Test Plan: <subject>"). Read its scenarios.
+        │   - If none exists, report and stop (run `/qw-plan` first).
+        │
+        ├─► Step 2: Coverage vs the story
         │   - [ ] Every item in the story's "Success Looks Like" maps to a scenario.
         │   - [ ] Nothing essential to verifying the story is missing.
         │   - [ ] No scenario goes beyond the story's need.
         │
-        ├─► Step 2: Each scenario
+        ├─► Step 3: Each scenario
         │   - [ ] One coherent slice; independently runnable.
-        │   - [ ] Maps to at least one cicd executable (or names the gap to author).
+        │   - [ ] Maps to at least one of the project's executables (or names the gap).
         │   - [ ] No duplication of a scenario already in docs/tests/ (grep the story link).
         │
-        └─► Step 3: Decision
-            - PASS: covers the story → proceed to `/qw-cases`.
-            - REVISE: name the missing or excess scenario; back to `/qw-plan`.
+        └─► Step 4: Decision (recorded on the issue)
+            - PASS: covers the story → comment "Reviewed — covers the story" on the issue;
+              proceed to `/qw-cases`.
+            - REVISE: comment the missing or excess scenario on the issue; back to `/qw-plan`.
 
 ---
 
 ## API Notes
 
 - Coverage gate only — step detail is `qw-cases`/`qw-review-cases`'s job.
-- Review paired with the producer `/qw-plan`.
+- Review paired with the producer `/qw-plan`; it gates the persisted
+  `[STORY-XXX] Test Plan` issue, recording PASS/REVISE as a comment on it.
 ```

--- a/docs/stories/STORY-005.md
+++ b/docs/stories/STORY-005.md
@@ -65,5 +65,5 @@ running rather than deferring them.
 
 - Created: 2026-06-21
 - Plan: #48
-- Issues: #49 (PR #53, open), #50, #51, #52
-- PRs: #53 (#49) — open
+- Issues: ✅ #49 (PR #53), #50, #51, #52
+- PRs: ✅ #53 (#49) — merged


### PR DESCRIPTION
## Summary
- Adopt upstream's `qw-plan` / `qw-review-plan` / `qw-cases` / `qw-review-cases` verbatim.
- Drops the **dead** `step-store` / `make query` / `make up` references — the runner has no `step-store/` dir and no such `Makefile` targets (vestigial from the `ai-qa-step-graph` lineage) — and the inline `qw-bind`/`qw-run` pointers.
- The runner's binding/run/drift specifics now resolve from `project-profile.md`'s "binding + run + drift layer" section + the runner's own `qw-bind`/`qw-review-bind`/`qw-drift` (untouched).
- **Behavior change (intended, confirmed):** `qw-plan` now persists scenarios as a `[STORY-XXX] Test Plan` GitHub issue (label `test-plan`) instead of a chat-only plan.

code-review (medium): clean. Every de-baked reference is recovered via the profile + the runner's own commands; no dangling refs; label/id-scheme/front-matter all consistent.

Fixes #50
Part of STORY-005 · plan #48

## Test plan
- [ ] `diff` each `qw-*` against upstream → identical
- [ ] `grep -rn "make query\|step-store\|make up" .claude/commands/qa-workflow/` → empty
- [ ] `qw-bind` / `qw-review-bind` / `qw-drift` / `dw-test-design` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)