### PR TITLE
Reconcile docs/tests contract to the seam architecture (#52)

### DIFF
--- a/docs/stories/STORY-005.md
+++ b/docs/stories/STORY-005.md
@@ -63,7 +63,8 @@ running rather than deferring them.
 
 ## Status
 
+- **Completed: 2026-06-21** — the runner now carries the upstream template's customization seam: `project-profile.md` holds every project-specific value, the generalized commands/skills/rules track upstream (re-syncable), and the runner's own binding/run/drift layer is preserved and declared as owned (PRs #53, #54, #55, #56).
 - Created: 2026-06-21
 - Plan: #48
-- Issues: ✅ #49 (PR #53), #50, #51, #52
-- PRs: ✅ #53 (#49) — merged
+- Issues: ✅ #49 (PR #53), ✅ #50 (PR #54), ✅ #51 (PR #55), ✅ #52 (PR #56)
+- PRs: ✅ #53 (#49), ✅ #54 (#50), ✅ #55 (#51), ✅ #56 (#52)

--- a/docs/tests/README.md
+++ b/docs/tests/README.md
@@ -1,9 +1,12 @@
 # `docs/tests/` — the test-doc format
 
 Each test is a **readable markdown document** that lives here, close to the story it verifies.
-The markdown owns **why / what** (intent); the bound `cicd/` YAML owns **how it runs**
-(execution). `qw-bind` links them, `qw-review-bind` audits the link, and `qw-drift` watches
-for divergence — all via `npm --prefix cicd/tests` (`audit-bind` / `drift` / `port-yaml`).
+The markdown owns **why / what** (intent) — that authoring format is the contract this file
+defines, shared with upstream's `qa-workflow`. The bound `cicd/` YAML owns **how it runs**
+(execution): `qw-bind` links them, `qw-review-bind` audits the link, and `qw-drift` watches for
+divergence — all via `npm --prefix cicd/tests` (`audit-bind` / `drift` / `port-yaml`). That
+binding + run + drift layer is **this runner's own**, beyond the shared authoring format — its
+authoritative declaration is `.claude/rules/project-profile.md` → "binding + run + drift layer".
 
 ## One file = one scenario (TS), many cases (TC)
 
@@ -58,7 +61,11 @@ status: green                   # green | stale | unbound  (maintained by qw-dri
 The Steps table is **machine-extractable** on purpose: one row = one `Action → Expected Result`,
 and the row count is what `audit-bind` compares to the YAML's `steps:`.
 
-## Binding, running, drift (this repo's job)
+## Binding, running, drift — this runner's layer (beyond the authoring contract)
+
+Upstream's `qa-workflow` defers binding + run to "the project's own layer"; this repo *is* that
+layer. The commands below are the concrete form of `project-profile.md` → "binding + run + drift
+layer".
 
 - **Bind** (`qw-bind`): set each TC's `Script:` to the `cicd/tests/testcases/**/*.yml` that runs
   it. Or revert: `npm --prefix cicd/tests run port-yaml -- <yaml>` scaffolds a doc from a YAML.
@@ -72,6 +79,7 @@ and the row count is what `audit-bind` compares to the YAML's `steps:`.
 
 - **story → tests:** `grep -l 'story: STORY-XXX' docs/tests/`
 - **test → story / script:** the front-matter `story:` and each case's `Script:` line.
+- **test → plan:** the front-matter `plan:` line (the `[STORY-XXX] Test Plan` issue number).
 - **script → test:** the `Script:` path points at the YAML.
 
 No hand-maintained index — the links live in the files and resolve by `grep`/path.


### PR DESCRIPTION
## Summary
- Targeted reconciliation of `docs/tests/README.md` (not a rewrite): the runner's contract already documented its real binding/run/drift layer and matched the profile's front-matter.
- Marks the authoring format as the contract **shared with upstream's `qa-workflow`**, and the binding/run/drift section as **this runner's own layer**, linked to `project-profile.md` → "binding + run + drift layer" as the authoritative declaration.
- Adds a **`test → plan`** traceability line — the `plan:` field now references a real `[STORY-XXX] Test Plan` GitHub issue (per #50).
- Deliberately does **not** adopt upstream's "binding is out of scope" stance: this repo *is* that layer.

This is the last task of STORY-005. code-review (medium): clean.

Fixes #52
Part of STORY-005 · plan #48

## Test plan
- [ ] `grep "audit-bind\|drift\|port-yaml" docs/tests/README.md` present; `grep "step-store\|make up" docs/tests/README.md` empty
- [ ] front-matter field list matches `project-profile.md`
- [ ] the binding section is marked as the runner's layer and links to the profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)