### PR TITLE
Chat-backend seam + generic MCP host + Ollama backend (#60)

### DIFF
--- a/cicd/tests/package-lock.json
+++ b/cicd/tests/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@agentclientprotocol/claude-agent-acp": "^0.44.0",
         "@agentclientprotocol/sdk": "^0.25.0",
+        "@modelcontextprotocol/sdk": "^1.0.0",
         "chalk": "^5.3.0",
         "commander": "^12.1.0",
         "glob": "^10.3.10",
@@ -23,14 +24,6 @@
       },
       "engines": {
         "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "@modelcontextprotocol/sdk": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@modelcontextprotocol/sdk": {
-          "optional": true
-        }
       }
     },
     "node_modules/@agentclientprotocol/claude-agent-acp": {
@@ -672,7 +665,6 @@
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
       "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.14.1"
       },
@@ -702,7 +694,6 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -777,7 +768,6 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mime-types": "^3.0.0",
         "negotiator": "^1.0.0"
@@ -791,7 +781,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -808,7 +797,6 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -862,7 +850,6 @@
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
       "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bytes": "^3.1.2",
         "content-type": "^1.0.5",
@@ -896,7 +883,6 @@
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -906,7 +892,6 @@
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -920,7 +905,6 @@
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "get-intrinsic": "^1.3.0"
@@ -976,7 +960,6 @@
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
       "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -990,7 +973,6 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1000,7 +982,6 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1010,7 +991,6 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.6.0"
       }
@@ -1020,7 +1000,6 @@
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
       "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "object-assign": "^4",
         "vary": "^1"
@@ -1052,7 +1031,6 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -1070,7 +1048,6 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -1080,7 +1057,6 @@
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -1100,8 +1076,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -1114,7 +1089,6 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -1124,7 +1098,6 @@
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -1134,7 +1107,6 @@
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -1144,7 +1116,6 @@
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
       "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -1198,15 +1169,13 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1216,7 +1185,6 @@
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "eventsource-parser": "^3.0.1"
       },
@@ -1229,7 +1197,6 @@
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
       "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       }
@@ -1239,7 +1206,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1283,7 +1249,6 @@
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
       "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ip-address": "^10.2.0"
       },
@@ -1301,8 +1266,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fast-sha256": {
       "version": "1.3.0",
@@ -1325,15 +1289,13 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "encodeurl": "^2.0.0",
@@ -1371,7 +1333,6 @@
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1381,7 +1342,6 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -1406,7 +1366,6 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -1416,7 +1375,6 @@
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
@@ -1441,7 +1399,6 @@
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -1488,7 +1445,6 @@
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -1501,7 +1457,6 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -1514,7 +1469,6 @@
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -1527,7 +1481,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
       "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1537,7 +1490,6 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "depd": "~2.0.0",
         "inherits": "~2.0.4",
@@ -1558,7 +1510,6 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
       "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -1574,15 +1525,13 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/ip-address": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
       "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 12"
       }
@@ -1592,7 +1541,6 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -1610,8 +1558,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -1639,7 +1586,6 @@
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
       "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -1674,15 +1620,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/json-schema-typed": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/lru-cache": {
       "version": "10.4.3",
@@ -1695,7 +1639,6 @@
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -1705,7 +1648,6 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -1715,7 +1657,6 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1728,7 +1669,6 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1738,7 +1678,6 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mime-db": "^1.54.0"
       },
@@ -1778,15 +1717,13 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1796,7 +1733,6 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1806,7 +1742,6 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -1819,7 +1754,6 @@
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -1832,7 +1766,6 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -1848,7 +1781,6 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -1883,7 +1815,6 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
       "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
@@ -1894,7 +1825,6 @@
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -1904,7 +1834,6 @@
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
@@ -1918,7 +1847,6 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
       "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "side-channel": "^1.1.0"
       },
@@ -1934,7 +1862,6 @@
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1944,7 +1871,6 @@
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
       "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bytes": "~3.1.2",
         "http-errors": "~2.0.1",
@@ -1960,7 +1886,6 @@
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1980,7 +1905,6 @@
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "depd": "^2.0.0",
@@ -1996,15 +1920,13 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
       "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.4.3",
         "encodeurl": "^2.0.0",
@@ -2031,7 +1953,6 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
       "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
@@ -2050,8 +1971,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -2079,7 +1999,6 @@
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
       "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.4",
@@ -2099,7 +2018,6 @@
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.4"
@@ -2116,7 +2034,6 @@
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -2135,7 +2052,6 @@
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -2178,7 +2094,6 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -2284,7 +2199,6 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -2321,7 +2235,6 @@
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
       "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
@@ -2340,7 +2253,6 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
       "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2375,7 +2287,6 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -2385,7 +2296,6 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -2500,8 +2410,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/zod": {
       "version": "4.4.3",
@@ -2517,7 +2426,6 @@
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
       "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
-      "peer": true,
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
       }

--- a/cicd/tests/package.json
+++ b/cicd/tests/package.json
@@ -15,11 +15,13 @@
     "audit-bind": "tsx src/audit-bind.ts",
     "drift": "tsx src/drift.ts",
     "port-yaml": "tsx src/port-yaml.ts",
-    "check:verifier": "tsx scripts/check-verifier-helpers.ts"
+    "check:verifier": "tsx scripts/check-verifier-helpers.ts",
+    "check:mcp-host": "tsx scripts/check-mcp-host.ts"
   },
   "dependencies": {
     "@agentclientprotocol/claude-agent-acp": "^0.44.0",
     "@agentclientprotocol/sdk": "^0.25.0",
+    "@modelcontextprotocol/sdk": "^1.0.0",
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
     "glob": "^10.3.10",
@@ -30,14 +32,6 @@
     "@types/node": "^20.14.0",
     "tsx": "^4.16.0",
     "typescript": "^5.5.0"
-  },
-  "peerDependencies": {
-    "@modelcontextprotocol/sdk": ">=1.0.0"
-  },
-  "peerDependenciesMeta": {
-    "@modelcontextprotocol/sdk": {
-      "optional": true
-    }
   },
   "engines": {
     "node": ">=18.0.0"

--- a/cicd/tests/scripts/check-mcp-host.ts
+++ b/cicd/tests/scripts/check-mcp-host.ts
@@ -1,0 +1,57 @@
+#!/usr/bin/env npx tsx
+/**
+ * Host-loop check: drive runMcpHost against the mock stdio MCP server with a STUB
+ * ChatBackend (canned tool call → final answer). Proves the generic loop works with
+ * no real model runtime. Run: npm run check:mcp-host
+ */
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { runMcpHost } from '../src/mcp/host.js';
+import type { ChatBackend, ChatRequest, ChatResponse } from '../src/mcp/chat-backend.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const tsxBin = join(here, '..', 'node_modules', '.bin', 'tsx');
+const mockServer = join(here, 'mock-mcp-server.ts');
+
+/** Round 1 → call get_fact; round 2 → final answer. No network. */
+class StubBackend implements ChatBackend {
+  readonly name = 'stub';
+  private round = 0;
+  async chat(_req: ChatRequest): Promise<ChatResponse> {
+    this.round++;
+    const metrics = { inTokens: 10, outTokens: 5, totalDurationNs: 1e9, evalDurationNs: 1e9 };
+    if (this.round === 1) {
+      return {
+        content: '',
+        toolCalls: [{ name: 'get_fact', arguments: {} }],
+        assistantMessage: { role: 'assistant', content: '', tool_calls: [{ function: { name: 'get_fact', arguments: {} } }] },
+        metrics,
+      };
+    }
+    return { content: 'The sky is blue (venue-3, id 5500).', toolCalls: [], metrics };
+  }
+}
+
+const traj = await runMcpHost({
+  backend: new StubBackend(),
+  model: 'stub-model',
+  prompt: 'Tell me the fact.',
+  servers: [{ name: 'mock', command: tsxBin, args: [mockServer] }],
+  numCtx: 2048,
+  timeoutMs: 30000,
+});
+
+assert.equal(traj.error, undefined, `no host error (got: ${traj.error})`);
+assert.equal(traj.supported, true, 'model supported');
+assert.deepEqual(traj.toolNames, ['get_fact'], 'server tool listed + merged');
+assert.equal(traj.toolCalls.length, 1, 'one tool call recorded');
+assert.equal(traj.toolCalls[0].name, 'get_fact', 'called the real tool');
+assert.equal(traj.toolResults.length, 1, 'one tool result recorded');
+assert.equal(traj.toolResults[0].isError, false, 'tool call succeeded against the real server');
+assert.ok(traj.toolResults[0].content.includes('5500'), 'captured the real server result');
+assert.ok(traj.finalAnswer.includes('blue'), 'final answer captured');
+assert.equal(traj.outTokens, 10, 'metrics summed across both rounds (5+5)');
+assert.equal(traj.maxPromptTokens, 10, 'peak prompt tokens tracked');
+
+process.stdout.write('\nmcp host: trajectory ok — supported, real tool call+result, final answer, metrics summed\n');

--- a/cicd/tests/scripts/mock-mcp-server.ts
+++ b/cicd/tests/scripts/mock-mcp-server.ts
@@ -1,0 +1,26 @@
+#!/usr/bin/env npx tsx
+/**
+ * Minimal stdio MCP server for host verification (no network, no real backend).
+ * Exposes one read-only tool, `get_fact`, returning a fixed payload. Uses the
+ * low-level Server API (stable across SDK versions).
+ */
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { ListToolsRequestSchema, CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+
+const server = new Server({ name: 'mock', version: '1.0.0' }, { capabilities: { tools: {} } });
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [
+    { name: 'get_fact', description: 'Return the known fact.', inputSchema: { type: 'object', properties: {}, required: [] } },
+  ],
+}));
+
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  if (req.params.name === 'get_fact') {
+    return { content: [{ type: 'text', text: 'The sky is blue. Venue venue-3 has id 5500.' }] };
+  }
+  return { content: [{ type: 'text', text: `unknown tool: ${req.params.name}` }], isError: true };
+});
+
+await server.connect(new StdioServerTransport());

--- a/cicd/tests/src/mcp/backends/index.ts
+++ b/cicd/tests/src/mcp/backends/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Backend factory — resolves a ChatBackend by name (config-selected).
+ * Adding a runtime = a new backends/<vendor>.ts + one case here. host.ts never changes.
+ */
+import type { ChatBackend } from '../chat-backend.js';
+import { OllamaBackend } from './ollama.js';
+
+export function makeBackend(name: string, opts: { host: string }): ChatBackend {
+  switch (name) {
+    case 'ollama':
+      return new OllamaBackend(opts.host);
+    default:
+      throw new Error(`unknown chat backend "${name}" (built-in: ollama)`);
+  }
+}

--- a/cicd/tests/src/mcp/backends/ollama.ts
+++ b/cicd/tests/src/mcp/backends/ollama.ts
@@ -1,0 +1,134 @@
+/**
+ * Ollama reference backend — the ONLY vendor-coupled module in the MCP path.
+ *
+ * Implements ChatBackend over Ollama's /api/chat. Everything Ollama-specific lives
+ * here: the HTTP endpoint, the response shape (message.tool_calls, prompt_eval_count,
+ * eval_duration, …), the "does not support tools" signal, the JSON-string arg quirk,
+ * and keep_alive:0 eviction. host.ts imports none of this — only the ChatBackend type.
+ */
+import http from 'node:http';
+import https from 'node:https';
+import type {
+  ChatBackend,
+  ChatRequest,
+  ChatResponse,
+  ChatToolCall,
+} from '../chat-backend.js';
+
+/** POST /api/chat over node:http so the per-call timeout is honored end-to-end.
+ *  fetch() (undici) imposes its own ~300s headers/body timeout that AbortSignal
+ *  can't lift — it silently kills slow generations at 5 min. node:http has no
+ *  such cap, so timeoutMs (via AbortSignal) is the only deadline. */
+function post(host: string, path: string, body: string, timeoutMs: number): Promise<any> {
+  const url = new URL(`${host}${path}`);
+  const transport = url.protocol === 'https:' ? https : http;
+  return new Promise((resolve, reject) => {
+    const req = transport.request(
+      url,
+      { method: 'POST', headers: { 'content-type': 'application/json', 'content-length': Buffer.byteLength(body) } },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (c: Buffer) => chunks.push(c));
+        // The response is a separate emitter from req — a reset mid-body (a real risk on a
+        // slow/OOMing backend) errors here, not on req. Without this it's an uncaught throw.
+        res.on('error', reject);
+        res.on('end', () => {
+          try {
+            resolve(JSON.parse(Buffer.concat(chunks).toString('utf8')));
+          } catch {
+            reject(new Error('ollama: invalid JSON response'));
+          }
+        });
+      },
+    );
+    const signal = AbortSignal.timeout(timeoutMs);
+    const onAbort = () => req.destroy(new Error(`ollama request timed out after ${timeoutMs}ms`));
+    signal.addEventListener('abort', onAbort, { once: true });
+    req.on('close', () => signal.removeEventListener('abort', onAbort));
+    req.on('error', reject);
+    req.end(body);
+  });
+}
+
+/** Ollama is documented to return tool-call arguments as an object, but some
+ *  model templates emit a JSON string — normalize both to an object. */
+function asArgs(raw: unknown): Record<string, unknown> {
+  if (typeof raw === 'string') {
+    try {
+      return JSON.parse(raw);
+    } catch {
+      return {};
+    }
+  }
+  return (raw ?? {}) as Record<string, unknown>;
+}
+
+const ZERO_METRICS = { inTokens: 0, outTokens: 0, totalDurationNs: 0, evalDurationNs: 0 };
+
+export class OllamaBackend implements ChatBackend {
+  readonly name = 'ollama';
+  constructor(private host: string) {}
+
+  async chat(req: ChatRequest): Promise<ChatResponse> {
+    const body = JSON.stringify({
+      model: req.model,
+      messages: req.messages,
+      tools: req.tools,
+      stream: false,
+      options: { temperature: 0, seed: 42, num_ctx: req.numCtx },
+    });
+
+    let raw: any;
+    try {
+      raw = await post(this.host, '/api/chat', body, req.timeoutMs);
+    } catch (e) {
+      return { content: '', toolCalls: [], error: e instanceof Error ? e.message : String(e), metrics: { ...ZERO_METRICS } };
+    }
+
+    if (!raw || typeof raw !== 'object') {
+      return { content: '', toolCalls: [], error: 'ollama /api/chat: no/invalid response', metrics: { ...ZERO_METRICS } };
+    }
+    // Ollama returns {error: "...does not support tools"} when the model's template
+    // can't do tool calling — a clean capability verdict, not a crash.
+    if (raw.error) {
+      const toolsUnsupported = /does not support tools/i.test(String(raw.error));
+      return { content: '', toolCalls: [], toolsUnsupported, error: String(raw.error), metrics: { ...ZERO_METRICS } };
+    }
+
+    const msg = raw.message ?? {};
+    const wireCalls = Array.isArray(msg.tool_calls) ? msg.tool_calls : [];
+    const toolCalls: ChatToolCall[] = wireCalls.map((tc: any) => ({
+      name: tc.function?.name ?? '',
+      arguments: asArgs(tc.function?.arguments),
+    }));
+
+    return {
+      content: msg.content ?? '',
+      toolCalls,
+      assistantMessage: { role: 'assistant', content: msg.content ?? '', tool_calls: wireCalls },
+      metrics: {
+        inTokens: raw.prompt_eval_count ?? 0,
+        outTokens: raw.eval_count ?? 0,
+        totalDurationNs: raw.total_duration ?? 0,
+        evalDurationNs: raw.eval_duration ?? 0,
+      },
+    };
+  }
+
+  /** Evict a model (keep_alive: 0). Best-effort: a benchmark loops over models
+   *  sequentially, so each must be released before the next loads — otherwise the
+   *  previous one stays resident and two models contend for the GPU. A failed
+   *  unload must never fail the test. */
+  async unload(model: string): Promise<void> {
+    try {
+      await fetch(`${this.host}/api/generate`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ model, keep_alive: 0 }),
+        signal: AbortSignal.timeout(30000),
+      });
+    } catch {
+      /* best-effort */
+    }
+  }
+}

--- a/cicd/tests/src/mcp/chat-backend.ts
+++ b/cicd/tests/src/mcp/chat-backend.ts
@@ -1,0 +1,84 @@
+/**
+ * ChatBackend — the vendor-neutral seam for the model-under-test.
+ *
+ * The MCP host loop (host.ts) drives a model through a real tool server but knows
+ * NOTHING about which model runtime it's talking to: it only calls `ChatBackend.chat()`.
+ * Every runtime-specific detail (HTTP endpoint, wire shapes, the "can't do tools"
+ * signal, arg coercion, token-eviction) lives in a backend under `backends/`.
+ *
+ * To target another runtime: implement `ChatBackend` in `backends/<vendor>.ts` and
+ * add one `case` to `backends/index.ts`. Do NOT edit host.ts. The reference backend
+ * is `backends/ollama.ts`.
+ *
+ * Message shape note: messages use the OpenAI/Ollama-style convention (a `tool_calls`
+ * array of `{ function: { name, arguments } }` on an assistant turn; a tool result as
+ * `{ role:'tool', content, tool_name }`). The host echoes these verbatim; a backend
+ * whose runtime differs translates them internally inside `chat()`.
+ */
+
+/** A tool offered to the model, in the OpenAI/Ollama "function" shape. */
+export interface ChatTool {
+  type: 'function';
+  function: { name: string; description: string; parameters: unknown };
+}
+
+/** A tool call as it appears on an assistant message (wire shape, echoed verbatim). */
+export interface ChatToolCallWire {
+  function: { name: string; arguments: unknown };
+}
+
+/** One conversation turn. `tool_calls` rides an assistant turn; `tool_name` a tool result. */
+export interface ChatMessage {
+  role: 'user' | 'assistant' | 'tool';
+  content: string;
+  tool_calls?: ChatToolCallWire[];
+  tool_name?: string;
+}
+
+/** One round's request: the conversation so far + the tool menu + decode options. */
+export interface ChatRequest {
+  model: string;
+  messages: ChatMessage[];
+  tools: ChatTool[];
+  numCtx: number;
+  timeoutMs: number;
+}
+
+/** A tool call normalized for the host: bare name + an args object (never a JSON string). */
+export interface ChatToolCall {
+  name: string;
+  arguments: Record<string, unknown>;
+}
+
+/** Per-round generation perf, named neutrally. Durations stay in nanoseconds so the
+ *  host's existing rounding/throughput math is unchanged. */
+export interface ChatMetrics {
+  inTokens: number;
+  outTokens: number;
+  totalDurationNs: number;
+  evalDurationNs: number;
+}
+
+/** One round's reply, normalized away from any vendor's wire shape. */
+export interface ChatResponse {
+  content: string;
+  /** Normalized tool calls for the host to execute + record. Empty ⇒ final answer. */
+  toolCalls: ChatToolCall[];
+  /** The assistant turn to echo back into the history before tool results (when toolCalls
+   *  is non-empty). The host pushes it verbatim; backends shape it for their runtime. */
+  assistantMessage?: ChatMessage;
+  /** The runtime signalled the model/template cannot do tools → a clean capability verdict. */
+  toolsUnsupported?: boolean;
+  /** A backend-level error string. The host returns a trajectory carrying it, never throws. */
+  error?: string;
+  metrics: ChatMetrics;
+}
+
+/** THE SEAM. The host loop calls only this; nothing else knows the runtime. */
+export interface ChatBackend {
+  /** Human label for reports (e.g. 'ollama'). */
+  readonly name: string;
+  chat(req: ChatRequest): Promise<ChatResponse>;
+  /** Optional: release model resources between models (e.g. Ollama keep_alive:0). */
+  unload?(model: string): Promise<void>;
+}

--- a/cicd/tests/src/mcp/host.ts
+++ b/cicd/tests/src/mcp/host.ts
@@ -1,0 +1,227 @@
+/**
+ * Vendor-neutral MCP host: let a model-under-test drive a real stdio MCP server's
+ * tools end-to-end (no mock).
+ *
+ * Connect to one or more stdio MCP servers (the spawn config is passed in), list
+ * their tools, hand them to the model as a single menu, then run the tool loop:
+ * chat → on tool calls, execute each against the *real* server via callTool → feed
+ * results back → chat again → final answer.
+ *
+ * What's tested is the MODEL: given a real menu, does it pick the right tool with
+ * valid args and use the result? The model runtime is reached ONLY through the
+ * injected `ChatBackend` (chat-backend.ts) — this file knows nothing vendor-specific.
+ * A model whose template lacks tool support is reported `supported:false` (a clean
+ * verdict, not a crash). The server choice + credentials are config, not code.
+ */
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport, getDefaultEnvironment } from '@modelcontextprotocol/sdk/client/stdio.js';
+import type { ChatBackend, ChatTool, ChatMessage } from './chat-backend.js';
+import type { McpServerConfig } from './server-config.js';
+
+export interface McpHostOptions {
+  /** The model runtime under test (the only thing that knows a vendor). */
+  backend: ChatBackend;
+  model: string;
+  prompt: string;
+  /** One or more stdio MCP servers whose tools are merged into a single menu the
+   *  model picks from. Two+ servers make "tool selection" a real choice; a tool call
+   *  routes back to its owning server. */
+  servers: McpServerConfig[];
+  numCtx?: number;
+  /** Max chat↔tool rounds before giving up (guards against a tool loop). */
+  maxIters?: number;
+  /** Per-call response timeout (ms). Default 600000 (10 min) — heavy models on slow
+   *  hardware need more than fetch's implicit ~5-min default. */
+  timeoutMs?: number;
+}
+
+export interface ToolCallRecord {
+  name: string;
+  arguments: Record<string, unknown>;
+}
+
+export interface ToolResultRecord {
+  name: string;
+  content: string;
+  isError: boolean;
+}
+
+export interface McpTrajectory {
+  model: string;
+  /** false ⇢ the model's template can't do tools (the backend signalled it). */
+  supported: boolean;
+  /** Tool names the MCP server(s) exposed (merged across servers). */
+  toolNames: string[];
+  /** Required arg names per tool, from each tool's inputSchema.required. */
+  toolRequired: Record<string, string[]>;
+  /** Which server each tool came from (toolName → server name) — lets a caller
+   *  pick out one server's tools (e.g. the verifier's read-only server). */
+  toolServer: Record<string, string>;
+  toolCalls: ToolCallRecord[];
+  toolResults: ToolResultRecord[];
+  finalAnswer: string;
+  /** Generation perf, summed across the chat↔tool rounds. */
+  inTokens: number;
+  /** Largest single round's prompt tokens — the value to compare against num_ctx
+   *  (summed inTokens spans rounds and can't be compared to the window). */
+  maxPromptTokens: number;
+  outTokens: number;
+  totalDurationS: number;
+  evalTps: number;
+  error?: string;
+}
+
+/** MCP tool {name, description?, inputSchema} → ChatTool entry (OpenAI "function" shape). */
+export function toChatTools(tools: Array<{ name: string; description?: string; inputSchema?: unknown }>): ChatTool[] {
+  return tools.map((t) => ({
+    type: 'function',
+    function: {
+      name: t.name,
+      description: t.description ?? '',
+      parameters: t.inputSchema ?? { type: 'object', properties: {} },
+    },
+  }));
+}
+
+const round2 = (n: number): number => Math.round(n * 100) / 100;
+const tps = (tokens: number, durNs: number): number => (durNs > 0 ? round2(tokens / (durNs / 1e9)) : 0);
+
+/** Join an MCP CallToolResult's content blocks into a single text payload. */
+function resultText(content: unknown): string {
+  if (!Array.isArray(content)) return '';
+  return content
+    .map((c: any) => (c?.type === 'text' && typeof c.text === 'string' ? c.text : JSON.stringify(c)))
+    .join('\n');
+}
+
+export async function runMcpHost(opts: McpHostOptions): Promise<McpTrajectory> {
+  const numCtx = opts.numCtx ?? 4096;
+  const maxIters = opts.maxIters ?? 5;
+  // Clamp to a sane (1s … 1h) window: rejects NaN/0/negative (→ default) and caps huge values that
+  // would overflow the 32-bit timer and abort instantly. Bad --timeout can't silently fail every model.
+  const reqMs = Number(opts.timeoutMs);
+  const timeoutMs = Number.isFinite(reqMs) && reqMs > 0 ? Math.min(reqMs, 3_600_000) : 600000;
+  let totalDurNs = 0;
+  let evalDurNs = 0;
+
+  // One client per server; their tools are merged into a single menu, and a tool
+  // call routes back to the server that owns the name (toolToClient).
+  const clients = opts.servers.map((s) => ({
+    name: s.name ?? 'mcp',
+    client: new Client({ name: 'mcp-host', version: '1.0.0' }),
+    transport: new StdioClientTransport({
+      command: s.command,
+      args: s.args,
+      cwd: s.cwd,
+      env: { ...getDefaultEnvironment(), ...(s.env ?? {}) },
+    }),
+  }));
+  const toolToClient = new Map<string, Client>();
+
+  const traj: McpTrajectory = {
+    model: opts.model,
+    supported: true,
+    toolNames: [],
+    toolRequired: {},
+    toolServer: {},
+    toolCalls: [],
+    toolResults: [],
+    finalAnswer: '',
+    inTokens: 0,
+    maxPromptTokens: 0,
+    outTokens: 0,
+    totalDurationS: 0,
+    evalTps: 0,
+  };
+
+  const messages: ChatMessage[] = [{ role: 'user', content: opts.prompt }];
+
+  try {
+    // Connect every server, list its tools, and merge into one menu. A tool name
+    // exposed by two servers can't be routed unambiguously — fail fast rather than
+    // silently send the call to the wrong one.
+    const merged: Array<{ name: string; description?: string; inputSchema?: unknown }> = [];
+    for (const { name: serverName, client, transport } of clients) {
+      await client.connect(transport);
+      const listed = await client.listTools();
+      for (const t of listed.tools) {
+        if (toolToClient.has(t.name)) {
+          throw new Error(`tool name collision: "${t.name}" exposed by "${traj.toolServer[t.name]}" and "${serverName}"`);
+        }
+        toolToClient.set(t.name, client);
+        traj.toolServer[t.name] = serverName;
+        traj.toolRequired[t.name] = Array.isArray((t.inputSchema as any)?.required) ? (t.inputSchema as any).required : [];
+        merged.push(t);
+      }
+    }
+    traj.toolNames = merged.map((t) => t.name);
+    const tools = toChatTools(merged);
+
+    for (let i = 0; i < maxIters; i++) {
+      const res = await opts.backend.chat({ model: opts.model, messages, tools, numCtx, timeoutMs });
+
+      // Backend signalled the model's template can't do tools — a clean capability verdict.
+      if (res.toolsUnsupported) {
+        traj.supported = false;
+        traj.error = res.error;
+        return traj;
+      }
+      if (res.error) {
+        traj.error = res.error;
+        return traj;
+      }
+
+      // Accumulate generation perf across the rounds (durations are ns).
+      traj.inTokens += res.metrics.inTokens;
+      traj.maxPromptTokens = Math.max(traj.maxPromptTokens, res.metrics.inTokens);
+      traj.outTokens += res.metrics.outTokens;
+      totalDurNs += res.metrics.totalDurationNs;
+      evalDurNs += res.metrics.evalDurationNs;
+      traj.totalDurationS = round2(totalDurNs / 1e9);
+      traj.evalTps = tps(traj.outTokens, evalDurNs);
+
+      if (res.toolCalls.length === 0) {
+        traj.finalAnswer = res.content;
+        return traj;
+      }
+
+      // Echo the assistant's tool-call turn, then run each call.
+      messages.push(res.assistantMessage ?? { role: 'assistant', content: res.content, tool_calls: [] });
+      for (const call of res.toolCalls) {
+        traj.toolCalls.push({ name: call.name, arguments: call.arguments });
+
+        // A bad tool name / args throws — but "the model picked wrong" is exactly
+        // the verdict under test, so capture it and feed it back, don't crash.
+        let content: string;
+        let isError: boolean;
+        const owner = toolToClient.get(call.name);
+        if (!owner) {
+          content = `tool call failed: unknown tool "${call.name}"`;
+          isError = true;
+        } else {
+          try {
+            const result: any = await owner.callTool({ name: call.name, arguments: call.arguments });
+            content = resultText(result?.content);
+            isError = Boolean(result?.isError);
+          } catch (e) {
+            content = `tool call failed: ${e instanceof Error ? e.message : String(e)}`;
+            isError = true;
+          }
+        }
+        traj.toolResults.push({ name: call.name, content, isError });
+        messages.push({ role: 'tool', content, tool_name: call.name });
+      }
+    }
+
+    // Ran out of iterations still calling tools — report what we have.
+    traj.error = `no final answer within ${maxIters} tool rounds`;
+    return traj;
+  } catch (e) {
+    // Connect/list/transport failure or a backend failure: return a trajectory
+    // carrying the error rather than throwing.
+    traj.error = e instanceof Error ? e.message : String(e);
+    return traj;
+  } finally {
+    for (const { client } of clients) await client.close().catch(() => {});
+  }
+}

--- a/docs/stories/STORY-006.md
+++ b/docs/stories/STORY-006.md
@@ -69,4 +69,4 @@ to point it at *their* system under test without editing shared code.
 
 - Created: 2026-06-21
 - Plan: #57
-- Issues: ✅ #58 (PR #64), #59, #60, #61, #62, #63
+- Issues: ✅ #58 (PR #64), ✅ #59 (PR #65), #60, #61, #62, #63


### PR DESCRIPTION
## Summary

- **`chat-backend.ts`** — the vendor-neutral `ChatBackend` seam (the one thing the host loop calls) + neutral message/tool/metrics types.
- **`backends/ollama.ts`** — the reference `OllamaBackend`, the ONLY vendor-coupled module: `/api/chat`, the `does not support tools` signal, JSON-string arg coercion, `keep_alive` eviction, and the `node:http` timeout rationale all live here.
- **`backends/index.ts`** — `makeBackend(name,{host})` factory; new runtime = new backend file + one `case`.
- **`host.ts`** — generic `runMcpHost` + `McpTrajectory` + `toChatTools`; consumes only `ChatBackend` + `McpServerConfig`. Behaviour-equivalent to the validated downstream loop (metrics order, error/unsupported handling, assistant-turn echo, tool-result messages).
- Promote `@modelcontextprotocol/sdk` from optional peer → dependency (host.ts is now built code).

Fixes #60
Part of STORY-006 (plan #57)

## Test plan

- [x] `npm run build` passes (tsc clean)
- [x] Vendor-neutrality grep gate: `host.ts` has no `ollama` / `/api/chat` / `prompt_eval`
- [x] `npm run check:mcp-host` — mock stdio MCP server + stub `ChatBackend` → trajectory captures the real tool call, result, final answer, summed metrics
- [ ] Real Ollama backend exercised end-to-end in #61 (test-mcp command)

Generated with [Claude Code](https://claude.com/claude-code)