### PR TITLE
test-mcp command wiring both MCP paths + config/.env (#61)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Dependencies
 node_modules/
 
+# Local env (secrets) — committed only as .env.example
+.env
+
 # Build output
 dist/
 

--- a/cicd/tests/.env.example
+++ b/cicd/tests/.env.example
@@ -1,0 +1,30 @@
+# Copy to .env and edit. Loaded automatically by config.ts (dotenv). .env is gitignored.
+
+# --- test-mcp: which real stdio MCP server to drive ---
+MCP_COMMAND=node dist/mcpServer.js
+MCP_ARGS=
+MCP_CWD=
+MCP_PROMPT=List the available items.
+# Comma-separated env var NAMES forwarded to the server as its credentials
+# (the values come from the real environment / CI secrets — never commit them here):
+MCP_ENV=
+# Example for a credentialed, containerized server:
+# MCP_COMMAND=docker
+# MCP_ARGS=run --rm -i -e MY_API_URL -e MY_API_KEY my-org/my-mcp:latest
+# MCP_ENV=MY_API_URL,MY_API_KEY
+# MY_API_URL=https://example.test
+# MY_API_KEY=...
+
+# --- chat backend (the model under test) ---
+MCP_BACKEND=ollama
+OLLAMA_HOST=http://localhost:11434
+
+# --- agent judge / verifier auth (for --judge and --verify-live) ---
+# Keyless on a Claude Code subscription. Locally uses ~/.claude; in CI set the token:
+# CLAUDE_CODE_OAUTH_TOKEN=
+# JUDGE_AGENT=                 # swap the ACP agent/model (empty = bundled Claude agent)
+
+# --- verifier (verify-live) isolation overrides (optional) ---
+# VERIFY_CONFIG_DIR=
+# VERIFY_DEBUG=0
+# VERIFY_VERBOSE=0

--- a/cicd/tests/package-lock.json
+++ b/cicd/tests/package-lock.json
@@ -13,6 +13,7 @@
         "@modelcontextprotocol/sdk": "^1.0.0",
         "chalk": "^5.3.0",
         "commander": "^12.1.0",
+        "dotenv": "^16.4.0",
         "glob": "^10.3.10",
         "js-yaml": "^4.1.0"
       },
@@ -1050,6 +1051,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/cicd/tests/package.json
+++ b/cicd/tests/package.json
@@ -15,8 +15,10 @@
     "audit-bind": "tsx src/audit-bind.ts",
     "drift": "tsx src/drift.ts",
     "port-yaml": "tsx src/port-yaml.ts",
+    "test:mcp": "tsx src/cli.ts test-mcp",
     "check:verifier": "tsx scripts/check-verifier-helpers.ts",
-    "check:mcp-host": "tsx scripts/check-mcp-host.ts"
+    "check:mcp-host": "tsx scripts/check-mcp-host.ts",
+    "check:mcp-test": "tsx scripts/check-mcp-test.ts"
   },
   "dependencies": {
     "@agentclientprotocol/claude-agent-acp": "^0.44.0",
@@ -24,6 +26,7 @@
     "@modelcontextprotocol/sdk": "^1.0.0",
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
+    "dotenv": "^16.4.0",
     "glob": "^10.3.10",
     "js-yaml": "^4.1.0"
   },

--- a/cicd/tests/scripts/check-mcp-test.ts
+++ b/cicd/tests/scripts/check-mcp-test.ts
@@ -1,0 +1,56 @@
+#!/usr/bin/env npx tsx
+/**
+ * test-mcp orchestration check (no real model needed):
+ *  1. SIMPLE mode — stub backend + mock stdio MCP server → exit 0 (model used the tool).
+ *  2. VERIFY-LIVE fail-closed — when the verifier cannot run, an otherwise-passing model
+ *     must FAIL (exit 1), never a false green. Triggered deterministically here via a
+ *     verify-server-name that matches no configured server (no agent spawn, no auth needed);
+ *     the agent-unavailable trigger routes through the identical fail-closed verdict path.
+ * Run: npm run check:mcp-test
+ */
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import type { ChatBackend, ChatRequest, ChatResponse } from '../src/mcp/chat-backend.js';
+import { runMcpTest } from '../src/mcp/test-mcp.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const tsxBin = join(here, '..', 'node_modules', '.bin', 'tsx');
+const mockServer = join(here, 'mock-mcp-server.ts');
+const servers = [{ name: 'mcp', command: tsxBin, args: [mockServer] }];
+
+/** Round 1 → call get_fact; round 2 → final answer. Fresh per run. */
+class Stub implements ChatBackend {
+  readonly name = 'stub';
+  private round = 0;
+  async chat(_req: ChatRequest): Promise<ChatResponse> {
+    this.round++;
+    const metrics = { inTokens: 10, outTokens: 5, totalDurationNs: 1e9, evalDurationNs: 1e9 };
+    if (this.round === 1) {
+      return {
+        content: '',
+        toolCalls: [{ name: 'get_fact', arguments: {} }],
+        assistantMessage: { role: 'assistant', content: '', tool_calls: [{ function: { name: 'get_fact', arguments: {} } }] },
+        metrics,
+      };
+    }
+    return { content: 'The sky is blue (venue-3, id 5500).', toolCalls: [], metrics };
+  }
+}
+
+// 1) Simple mode — structural check passes ⇒ exit 0.
+const simpleCode = await runMcpTest({
+  models: ['stub'], prompt: 'Tell me the fact.', servers, backend: new Stub(),
+  numCtx: 2048, judge: false, timeoutMs: 30000,
+});
+assert.equal(simpleCode, 0, 'simple mode: model used the tool + produced an answer ⇒ pass');
+
+// 2) verify-live that cannot run (no server matches --verify-server-name) ⇒ FAIL CLOSED.
+const verifyCode = await runMcpTest({
+  models: ['stub'], prompt: 'Tell me the fact.', servers, backend: new Stub(),
+  numCtx: 2048, judge: false, verifyLive: true, verifyAllow: ['get_fact'],
+  verifyServerName: 'no-such-server', timeoutMs: 30000,
+});
+assert.equal(verifyCode, 1, 'verify-live that cannot run FAILS closed (never a false green)');
+
+process.stdout.write('\ntest-mcp: simple mode passes; verify-live fails closed when it cannot run\n');

--- a/cicd/tests/src/cli.ts
+++ b/cicd/tests/src/cli.ts
@@ -15,7 +15,9 @@ import { TestExecutor } from './executor.js';
 import { SimpleJudge, AgentJudge } from './judge/index.js';
 import { JsonReporter, ConsoleReporter } from './reporter/index.js';
 import { RunConfig, DEFAULT_CONFIG } from './types.js';
-import { CONFIG } from './config.js';
+import { CONFIG, pickEnv } from './config.js';
+import { runMcpTest } from './mcp/test-mcp.js';
+import { makeBackend } from './mcp/backends/index.js';
 
 const program = new Command();
 
@@ -221,6 +223,70 @@ program
 
     console.log('\n' + '='.repeat(60));
     console.log(`Total: ${testCases.length} test(s)`);
+  });
+
+/**
+ * test-mcp — can a model drive a REAL MCP server's tools end-to-end?
+ *
+ * Connects to a stdio MCP server (config/.env defaults; override with --mcp-command/
+ * --mcp-args), lists + hands its tools to the model, and runs the tool loop via the
+ * configured ChatBackend. Per-model verdict: structural check always; --judge adds the
+ * keyless AgentJudge over the captured trajectory; --verify-live has the judge call the
+ * server's read-only tools itself to check against live truth. Server-agnostic — no mock.
+ */
+program
+  .command('test-mcp')
+  .description("Test whether models can drive a real MCP server's tools")
+  .argument('<models...>', 'One or more model names to test')
+  .option('--prompt <text>', 'Prompt that should trigger a tool call', CONFIG.mcp.prompt)
+  .option('-c, --num-ctx <n>', 'Context window size', '8192')
+  .option('--judge', 'Also run the agent judge on the final answer (dual mode)', false)
+  .option('-H, --host <url>', 'Backend host (e.g. the Ollama host)', CONFIG.mcp.host)
+  .option('--backend <name>', 'Chat backend (model runtime) — built-in: ollama', CONFIG.mcp.backend)
+  .option('--mcp-command <cmd>', 'Command to launch the stdio MCP server', CONFIG.mcp.command)
+  .option('--mcp-args <args>', 'Args for the MCP server (space-separated; no spaces within a single arg)', CONFIG.mcp.args.join(' '))
+  .option('--mcp-env <names>', 'Comma-separated env var names to forward to the server as creds (overrides MCP_ENV)', '')
+  .option('--distractor-command <cmd>', 'Optional second (menu-only) MCP server — its tools join the menu as distractors the model must NOT pick; the verifier never touches it')
+  .option('--distractor-args <args>', 'Args for the distractor MCP server (space-separated; no spaces within a single arg)', '')
+  .option('--verify-live', "Verify the answer against LIVE truth: the judge calls the server's read-only tools itself (supersedes --judge)", false)
+  .option('--verify-allow <names>', 'Comma-separated exact tool names the verifier may call (fail-closed: empty verifies nothing)', '')
+  .option('--verify-server-name <name>', 'Name of the server the verifier spawns (the primary server is registered under this name); its tools are mcp__<name>__<tool>', 'mcp')
+  .option('--timeout <seconds>', 'Per-call response timeout', '1800')
+  .option('-o, --output <file>', 'Write the JSON report to this file')
+  .action(async (models: string[], options) => {
+    const code = await runMcpTest({
+      models,
+      prompt: options.prompt,
+      numCtx: Number(options.numCtx),
+      timeoutMs: Number(options.timeout) * 1000,
+      judge: options.judge,
+      verifyLive: options.verifyLive,
+      verifyAllow: options.verifyAllow ? String(options.verifyAllow).split(',').map((s: string) => s.trim()).filter(Boolean) : undefined,
+      verifyServerName: options.verifyServerName,
+      backend: makeBackend(options.backend, { host: options.host }),
+      // Primary server (the verifier's read-only target) is named after --verify-server-name
+      // so the verifier can find it. An optional distractor server joins the model's menu only.
+      servers: [
+        {
+          name: options.verifyServerName,
+          command: options.mcpCommand,
+          args: String(options.mcpArgs).split(' ').filter(Boolean),
+          cwd: CONFIG.mcp.cwd,
+          env: options.mcpEnv ? pickEnv(options.mcpEnv) : CONFIG.mcp.env,
+        },
+        ...(options.distractorCommand
+          ? [{
+              name: 'distractor',
+              command: options.distractorCommand,
+              args: String(options.distractorArgs).split(' ').filter(Boolean),
+            }]
+          : []),
+      ],
+      output: options.output,
+    });
+    // Flush stdout before forcing exit — the markdown summary is piped to tee in CI.
+    await new Promise<void>((resolve) => process.stdout.write('', () => resolve()));
+    process.exit(code);
   });
 
 program.parse();

--- a/cicd/tests/src/config.ts
+++ b/cicd/tests/src/config.ts
@@ -4,12 +4,28 @@
  * Customize this file for your project's needs.
  */
 
+import 'dotenv/config'; // load cicd/tests/.env into process.env before any value below is read
+
 /**
  * Available test suites - extend this array for your project.
  * Examples: ['build', 'integration', 'e2e'] or ['build', 'runtime', 'inference', 'models']
  */
 export const SUITES: string[] = ['build', 'integration', 'e2e'];
 export type Suite = string;
+
+/**
+ * Pick a subset of environment variables by NAME → { name: value } map.
+ * Forwards a server's credentials (e.g. "API_URL,API_KEY") without hardcoding the
+ * values — they come from the environment / CI secrets.
+ */
+export function pickEnv(names: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const n of names.split(',').map((s) => s.trim()).filter(Boolean)) {
+    const v = process.env[n];
+    if (v !== undefined) out[n] = v;
+  }
+  return out;
+}
 
 /**
  * Project configuration.
@@ -50,7 +66,19 @@ export const CONFIG = {
 
   // MCP client settings (for projects using mcp-client.ts)
   mcp: {
-    serverCommand: 'node dist/mcpServer.js', // Override via MCP_SERVER_COMMAND env var
+    // Legacy: the single-tool client (mcp-client.ts) reads MCP_SERVER_COMMAND directly.
+    serverCommand: 'node dist/mcpServer.js',
+
+    // test-mcp (target + verifier paths): which real stdio MCP server to drive, and
+    // which model runtime drives it. Generic defaults — point them at your server/runtime
+    // via .env (see .env.example). Credentials are forwarded by NAME via MCP_ENV.
+    command: process.env.MCP_COMMAND || 'node dist/mcpServer.js',
+    args: (process.env.MCP_ARGS || '').split(' ').filter(Boolean),
+    cwd: process.env.MCP_CWD || undefined,
+    prompt: process.env.MCP_PROMPT || 'List the available items.',
+    env: pickEnv(process.env.MCP_ENV || ''),
+    backend: process.env.MCP_BACKEND || 'ollama', // selects the ChatBackend (model runtime)
+    host: process.env.OLLAMA_HOST || 'http://localhost:11434', // ollama backend host
   },
 };
 

--- a/cicd/tests/src/mcp/test-mcp.ts
+++ b/cicd/tests/src/mcp/test-mcp.ts
@@ -1,0 +1,304 @@
+/**
+ * Per-model MCP tool-call test (the cli.ts test-mcp subcommand).
+ *
+ * For each model: drive a REAL stdio MCP server through the host (host.ts) and
+ * grade the trajectory. The simple check is structural (did the model call a
+ * real tool, did the call succeed, did it produce a final answer?); with
+ * --judge the keyless AgentJudge adds the semantic check (did the final answer
+ * correctly use the tool result?); with --verify-live the VerifierJudge calls
+ * the server's read-only tools itself to check against LIVE truth. A model whose
+ * template can't do tools is reported "no tool support" — a clean verdict, not a
+ * failure of the harness.
+ *
+ * Markdown summary on stdout (CI step summary) and, with --output, a JSON report.
+ * Exit code is non-zero if any supported model fails. The model runtime is reached
+ * only through the injected ChatBackend (host.ts) — this file is vendor-neutral.
+ */
+import { writeFileSync } from 'node:fs';
+import { runMcpHost, type McpTrajectory } from './host.js';
+import type { McpServerConfig } from './server-config.js';
+import type { ChatBackend } from './chat-backend.js';
+import { AgentJudge, VerifierJudge } from '../judge/index.js';
+import { TestResult, Judgment } from '../types.js';
+
+const JUDGE_CRITERIA =
+  'Given the user prompt and the tool result(s) the model received, the final answer must ' +
+  'correctly use the tool result to answer the prompt. Reject empty answers, answers that ' +
+  'ignore or contradict the tool result, or data the tool result does not contain.';
+
+export interface McpTestOptions {
+  models: string[];
+  prompt: string;
+  /** Servers whose tools are merged into one menu for the model. With more than one,
+   *  picking the right tool is a real choice — extra servers act as distractors. */
+  servers: McpServerConfig[];
+  /** The model runtime under test (the only vendor-aware object). */
+  backend: ChatBackend;
+  numCtx: number;
+  judge: boolean;
+  /** Opt in the live verifier: the judge calls the server's read-only tools itself
+   *  to check the answer against live ground truth (supersedes --judge). */
+  verifyLive?: boolean;
+  /** Exact tool names the verifier may call. Fail-closed: if empty/unset, the verifier
+   *  verifies nothing — pass an explicit allow-list (no prefix heuristic across servers). */
+  verifyAllow?: string[];
+  /** Selects WHICH server the verifier spawns (by McpServerConfig.name) and the
+   *  mcp__<name>__<tool> label it registers it under — the verifier only ever sees
+   *  this one server, so distractor servers stay out of its reach. */
+  verifyServerName?: string;
+  /** Per-model response timeout (ms). Default 600000 (10 min). */
+  timeoutMs?: number;
+  output?: string;
+}
+
+interface McpSimpleVerdict {
+  pass: boolean;
+  reason: string;
+}
+
+interface McpModelResult {
+  model: string;
+  supported: boolean;
+  tool_names: string[];
+  tool_calls: { name: string; arguments: Record<string, unknown> }[];
+  tool_results: { name: string; isError: boolean }[];
+  final_answer_preview: string;
+  error?: string;
+  out_tokens: number;
+  max_prompt_tokens: number;
+  total_duration_s: number;
+  eval_tps: number;
+  check: { overall_pass: boolean; simple: McpSimpleVerdict; agent: Judgment | null };
+}
+
+/** Structural check: the model must have called a real tool, the call must have
+ *  succeeded, and it must have produced a non-empty final answer. */
+function simpleMcpCheck(t: McpTrajectory): McpSimpleVerdict {
+  if (!t.supported) return { pass: false, reason: 'model template does not support tools' };
+  if (t.error) return { pass: false, reason: t.error };
+  if (t.toolCalls.length === 0) return { pass: false, reason: 'model produced no tool call' };
+  const unknown = t.toolCalls.find((c) => !t.toolNames.includes(c.name));
+  if (unknown) return { pass: false, reason: `called unknown tool "${unknown.name}"` };
+  // Args vs schema: every required arg of the called tool must be present.
+  for (const c of t.toolCalls) {
+    const missing = (t.toolRequired[c.name] ?? []).filter((k) => !(k in c.arguments));
+    if (missing.length) return { pass: false, reason: `tool "${c.name}" called without required arg(s): ${missing.join(', ')}` };
+  }
+  const errored = t.toolResults.find((r) => r.isError);
+  if (errored) return { pass: false, reason: `tool "${errored.name}" call failed (bad args or server error)` };
+  if (!t.finalAnswer.trim()) return { pass: false, reason: 'empty final answer' };
+  return { pass: true, reason: `called ${t.toolCalls.map((c) => c.name).join(', ')} and produced a final answer` };
+}
+
+/** Build a synthetic TestResult so the AgentJudge can grade groundedness.
+ *  Lead with the prompt + final answer: the judge truncates step stdout, so a
+ *  large tool result must not push the answer out of the judge's window. Each
+ *  tool result is capped to keep enough grounding context within that window. */
+function toTestResult(t: McpTrajectory, prompt: string): TestResult {
+  const toolLog = t.toolCalls
+    .map((c, i) => `- ${c.name}(${JSON.stringify(c.arguments)}) -> ${(t.toolResults[i]?.content ?? '').slice(0, 500)}`)
+    .join('\n');
+  const stdout = `PROMPT: ${prompt}\n\nFINAL ANSWER: ${t.finalAnswer}\n\nTOOL CALLS AND RESULTS:\n${toolLog}`;
+  return {
+    testCase: {
+      id: t.model,
+      name: `mcp:${t.model}`,
+      suite: 'mcp',
+      priority: 1,
+      timeout: 60000,
+      dependencies: [],
+      goal: 'Use the MCP tool result to answer the prompt',
+      steps: [{ name: 'tool-call', command: '(captured MCP trajectory)' }],
+      criteria: JUDGE_CRITERIA,
+    },
+    steps: [{ name: 'tool-call', command: '(captured MCP trajectory)', stdout, stderr: '', exitCode: 0, duration: 0 }],
+    totalDuration: 0,
+    logs: '',
+    logFile: '',
+  };
+}
+
+export async function runMcpTest(opts: McpTestOptions): Promise<number> {
+  const results: McpModelResult[] = [];
+  const trajByModel = new Map<string, McpTrajectory>();
+
+  for (const model of opts.models) {
+    process.stderr.write(`--- ${model} ---\n`);
+    const traj = await runMcpHost({ backend: opts.backend, model, prompt: opts.prompt, servers: opts.servers, numCtx: opts.numCtx, timeoutMs: opts.timeoutMs });
+    trajByModel.set(model, traj);
+    const simple = simpleMcpCheck(traj);
+    results.push({
+      model,
+      supported: traj.supported,
+      tool_names: traj.toolNames,
+      tool_calls: traj.toolCalls,
+      tool_results: traj.toolResults.map((r) => ({ name: r.name, isError: r.isError })),
+      final_answer_preview: traj.finalAnswer.slice(0, 200),
+      error: traj.error,
+      out_tokens: traj.outTokens,
+      max_prompt_tokens: traj.maxPromptTokens,
+      total_duration_s: traj.totalDurationS,
+      eval_tps: traj.evalTps,
+      check: { overall_pass: simple.pass, simple, agent: null },
+    });
+    process.stderr.write(`  supported=${traj.supported} calls=${traj.toolCalls.length} simple=${simple.pass} · ${traj.outTokens} tok @ ${traj.evalTps} tok/s in ${traj.totalDurationS}s\n`);
+    // Release this model before the next loads, so only one is ever resident (no contention).
+    await opts.backend.unload?.(model);
+  }
+
+  // Agent-level check, only for models that passed the structural check. Two modes:
+  //  --verify-live : the verifier calls the server's read-only tools itself to check
+  //                  the answer against LIVE truth (the stronger check; supersedes --judge).
+  //  --judge       : the sandboxed agent judge grades groundedness over the captured trajectory.
+  const eligible = results.filter((r) => r.check.simple.pass);
+  const byModel = new Map(results.map((r) => [r.model, r]));
+  const applyVerdicts = (verdicts: Judgment[]) => {
+    for (const v of verdicts) {
+      const r = byModel.get(v.testId);
+      if (r) {
+        r.check.agent = v;
+        r.check.overall_pass = r.check.simple.pass && v.pass;
+      }
+    }
+  };
+
+  if (eligible.length > 0 && opts.verifyLive) {
+    // The verifier spawns ONLY its named server (read-only, fail-closed); distractor
+    // servers on the model's menu never reach it. Hand it that server's tools only —
+    // filtered by which server each came from — so its deny-list doesn't sprout bogus
+    // rules for tools it can't even see. Fail-closed: only --verify-allow opens tools.
+    const verifyServerName = opts.verifyServerName ?? 'mcp';
+    const verifyServer = opts.servers.find((s) => (s.name ?? 'mcp') === verifyServerName);
+    const toolServer = trajByModel.get(eligible[0].model)?.toolServer ?? {};
+    const verifyToolNames = Array.from(new Set(eligible.flatMap((r) => r.tool_names))).filter((n) => toolServer[n] === verifyServerName);
+    const allowTools = opts.verifyAllow ?? [];
+    if (!verifyServer) {
+      // Misconfigured: verify-live asked, but no server matches the name. Don't fall back
+      // to some other server (could be a distractor) — fail closed.
+      process.stderr.write(`[ERROR] verify-live: no configured server named "${verifyServerName}" — failing closed\n`);
+      applyVerdicts(eligible.map((r) => ({
+        testId: r.model,
+        pass: false,
+        reason: `verify-live could not run: no server named "${verifyServerName}"`,
+        evidenceStatus: 'verifier-unavailable' as const,
+      })));
+    } else {
+      const verifier = new VerifierJudge(
+        { server: verifyServer, serverName: verifyServerName, toolNames: verifyToolNames, allowTools },
+        '',
+      );
+      if (await verifier.isAvailable()) {
+        applyVerdicts(
+          await verifier.verify(eligible.map((r) => ({ testId: r.model, prompt: opts.prompt, answer: trajByModel.get(r.model)!.finalAnswer, toolCalls: r.tool_calls }))),
+        );
+      } else {
+        // Fail closed: a verify-live run whose verifier can't even start has NOT verified anything,
+        // so it must not green-light on the structural check alone. Mark every eligible model FAIL.
+        process.stderr.write('[ERROR] verify-live requested but the verifier agent is unavailable (auth/availability) — failing closed\n');
+        applyVerdicts(eligible.map((r) => ({
+          testId: r.model,
+          pass: false,
+          reason: 'verify-live could not run: verifier agent unavailable (auth/availability)',
+          evidenceStatus: 'verifier-unavailable' as const,
+        })));
+      }
+    }
+  } else if (eligible.length > 0 && opts.judge) {
+    const agentJudge = new AgentJudge();
+    if (await agentJudge.isAvailable()) {
+      applyVerdicts(await agentJudge.judgeResults(eligible.map((r) => toTestResult(trajByModel.get(r.model)!, opts.prompt))));
+    } else {
+      process.stderr.write('[WARN] agent judge not available — simple check only\n');
+    }
+  }
+
+  // "No tool support" is an informational capability verdict, not a harness
+  // failure — only a supported model that failed its check drives a non-zero exit.
+  const failed = results.filter((r) => r.supported && !r.check.overall_pass).length;
+
+  if (opts.output) {
+    const full = results.map((r) => ({ ...r, trajectory: trajByModel.get(r.model) }));
+    writeFileSync(
+      opts.output,
+      JSON.stringify(
+        { timestamp: new Date().toISOString(), backend: opts.backend.name, servers: opts.servers.map((s) => ({ name: s.name ?? 'mcp', command: s.command, args: s.args })), prompt: opts.prompt, judge: judgeLabel(opts), results: full },
+        null,
+        2
+      )
+    );
+    process.stderr.write(`Results written to ${opts.output}\n`);
+  }
+
+  printSummary(opts, results);
+  return failed > 0 ? 1 : 0;
+}
+
+/** Turn an empty evidence cell into a one-glance reason instead of a bare "—" (STORY-010). */
+function evidenceWhy(status: Judgment['evidenceStatus']): string {
+  switch (status) {
+    case 'denied': return '— (tool denied)';
+    case 'not-called': return '— (no tool called)';
+    case 'no-data': return '— (tool returned no data)';
+    case 'verifier-unavailable': return '— (verifier did not run)';
+    default: return '—';
+  }
+}
+
+const tick = (b: boolean): string => (b ? '✅' : '❌');
+/** Peak single-round prompt tokens vs the context window — ⚠️ within 10% of num_ctx
+ *  (a prompt that crosses it is silently truncated). */
+const peakCtx = (peak: number, numCtx: number): string =>
+  peak > 0 ? `${peak > numCtx * 0.9 ? '⚠️ ' : ''}${peak}/${numCtx}` : '—';
+const judgeLabel = (opts: McpTestOptions): string => (opts.verifyLive ? 'verify-live' : opts.judge ? 'dual' : 'simple');
+/** Escape so model/server-controlled text can't break out of the Markdown/<details>/code block. */
+const mdSafe = (s: string): string => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+function printSummary(opts: McpTestOptions, results: McpModelResult[]): void {
+  const supported = results.filter((r) => r.supported);
+  const passed = supported.filter((r) => r.check.overall_pass).length;
+  const failed = supported.length - passed;
+  const sha = process.env.GITHUB_SHA?.slice(0, 8);
+  const out: string[] = [];
+
+  // Banner — a glance tells you the outcome. ⚪ when nothing was actually verified (don't fake a green).
+  const icon = failed > 0 ? '❌' : passed > 0 ? '✅' : '⚪';
+  out.push(`## 🧪 MCP tool-call test — ${icon} ${passed} passed · ${failed} failed`);
+  out.push('');
+  const serverLabel = opts.servers.map((s) => `\`${s.command} ${s.args.join(' ')}\``).join(' + ');
+  out.push(`**Server${opts.servers.length > 1 ? 's' : ''}:** ${serverLabel}`);
+  out.push(`**Prompt:** ${opts.prompt} · **Backend:** ${opts.backend.name} · **Judge:** ${judgeLabel(opts)}${sha ? ` · **Commit:** \`${sha}\`` : ''}`);
+  out.push('');
+
+  // Scannable table — judge stages + cross-check, no raw JSON in the cells.
+  out.push('| Model | Verdict | Tool call(s) | Judge stages (tool·query·content) | Cross-check | Time (s) | Peak in/ctx | Out tok | tok/s |');
+  out.push('|---|---|---|---|---|--:|--:|--:|--:|');
+  for (const r of results) {
+    const verdict = r.check.overall_pass ? '✅ PASS' : r.supported ? '❌ FAIL' : '⚪ NO TOOL SUPPORT';
+    const calls = r.tool_calls.map((c) => c.name).join(', ') || '—';
+    const s = r.check.agent?.stages;
+    const stages = s ? `${tick(s.tool)} · ${tick(s.query)} · ${tick(s.content)}` : '—';
+    const cc = r.check.agent?.crossCheckUnsupported;
+    const cross = cc === undefined ? '—' : cc.length ? `❌ ${cc.join(', ').slice(0, 60)}` : '✅ grounded';
+    out.push(`| ${r.model} | ${verdict} | ${calls} | ${stages} | ${cross} | ${r.total_duration_s || '—'} | ${peakCtx(r.max_prompt_tokens, opts.numCtx)} | ${r.out_tokens || '—'} | ${r.eval_tps || '—'} |`);
+  }
+
+  // Per-model detail (reasoning + raw evidence) tucked behind a toggle — proof without the clutter.
+  for (const r of results) {
+    const reason = (r.check.agent?.reason ?? r.check.simple.reason ?? '').trim();
+    const evidence = r.check.agent?.evidence ?? '';
+    out.push('');
+    out.push(`<details><summary>Judge detail — ${mdSafe(r.model)}</summary>`);
+    out.push('');
+    if (reason) out.push(`**Reasoning:** ${mdSafe(reason.replace(/\n/g, ' '))}`);
+    out.push('');
+    if (evidence) {
+      // HTML-escaped <pre> (not a ``` fence) so a ``` or </details> in the result can't break out.
+      out.push('**Live evidence:**');
+      out.push(`<pre>${mdSafe(evidence.slice(0, 4000))}</pre>`);
+    } else {
+      out.push(`**Live evidence:** ${evidenceWhy(r.check.agent?.evidenceStatus)}`);
+    }
+    out.push('</details>');
+  }
+  process.stdout.write(out.join('\n') + '\n');
+}

--- a/docs/stories/STORY-006.md
+++ b/docs/stories/STORY-006.md
@@ -69,4 +69,4 @@ to point it at *their* system under test without editing shared code.
 
 - Created: 2026-06-21
 - Plan: #57
-- Issues: ✅ #58 (PR #64), ✅ #59 (PR #65), #60, #61, #62, #63
+- Issues: ✅ #58 (PR #64), ✅ #59 (PR #65), ✅ #60 (PR #66), #61, #62, #63


### PR DESCRIPTION
## Summary

- **`test-mcp` CLI command** (`cli.ts`): structural check always; `--judge` adds the keyless AgentJudge over the captured trajectory; `--verify-live` has the `VerifierJudge` call the server's read-only tools itself against live truth. Markdown summary → stdout (CI step summary) + `--output` JSON.
- **`mcp/test-mcp.ts`** — ported `runMcpTest`/`simpleMcpCheck`/`toTestResult`/`printSummary`, backend-agnostic (model runtime built via `makeBackend`, so the command is vendor-neutral).
- **`config.ts`** — dotenv bootstrap (first import), `pickEnv`, and an MCP block (`command/args/cwd/prompt/env/backend/host`) with generic defaults, alongside the legacy `serverCommand`.
- `.env.example`, the `dotenv` dependency, a `test:mcp` script, and `.env` gitignored.

Fixes #61
Part of STORY-006 (plan #57)

## Test plan

- [x] `npm run build` passes; `test-mcp` registered (`--help`)
- [x] `npm run check:mcp-test` — simple mode passes (mock server + stub backend); **verify-live fails closed** (exit 1) when it cannot run
- [x] Observed: with Claude auth, `--verify-live` performs a real live verification (agent calls the tool, grades grounded)
- [x] Regression: `npm test` (`run`), `check:verifier`, `check:mcp-host` all green; `.env` not committed

Generated with [Claude Code](https://claude.com/claude-code)