### PR TITLE
MCP CI workflow + example testcase (#62)

### DIFF
--- a/.github/workflows/test-mcp.yml
+++ b/.github/workflows/test-mcp.yml
@@ -1,0 +1,109 @@
+name: "Test: MCP tool-call"
+
+# Drives a model through a real MCP server's tools and grades it.
+#   mode: simple      — structural check (model called a real tool, valid args, answer)
+#         judge       — + keyless AgentJudge over the captured trajectory
+#         verify-live — + the judge calls the server's read-only tools itself vs live truth
+#
+# Prerequisites (this is a real integration, not a unit test):
+#   - a reachable stdio MCP server — configure via repo Variables MCP_COMMAND / MCP_ARGS
+#     / MCP_ENV (names of secrets to forward), or your project's defaults in config.ts
+#   - a reachable model runtime — MCP_BACKEND (default ollama) + OLLAMA_HOST
+#   - for judge / verify-live: CLAUDE_CODE_OAUTH_TOKEN secret (keyless agent auth)
+# A GitHub-hosted runner has neither a model host nor your MCP server by default —
+# run on a self-hosted runner, or wire the server/host through the env below.
+
+on:
+  workflow_dispatch:
+    inputs:
+      models:
+        description: "Space-separated model names to test"
+        required: true
+        type: string
+      prompt:
+        description: "Prompt that should trigger a tool call (blank = config default)"
+        required: false
+        type: string
+      mode:
+        description: "Judge mode"
+        required: false
+        default: "simple"
+        type: choice
+        options: ["simple", "judge", "verify-live"]
+      verify_allow:
+        description: "verify-live: comma-separated read-only tool names the verifier may call"
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      models:
+        required: true
+        type: string
+      prompt:
+        required: false
+        type: string
+      mode:
+        required: false
+        default: "simple"
+        type: string
+      verify_allow:
+        required: false
+        type: string
+
+jobs:
+  test-mcp:
+    name: "Test: MCP tool-call"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: cd cicd/tests && npm ci
+
+      - name: Build test runner
+        run: cd cicd/tests && npm run build
+
+      - name: Run MCP tool-call test
+        env:
+          # Keyless agent auth for --judge / --verify-live (empty JUDGE_AGENT = bundled Claude agent).
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          JUDGE_AGENT: ${{ vars.JUDGE_AGENT }}
+          # Which real MCP server + model runtime to use (see config.ts / .env.example).
+          MCP_COMMAND: ${{ vars.MCP_COMMAND }}
+          MCP_ARGS: ${{ vars.MCP_ARGS }}
+          MCP_ENV: ${{ vars.MCP_ENV }}
+          MCP_BACKEND: ${{ vars.MCP_BACKEND }}
+          OLLAMA_HOST: ${{ vars.OLLAMA_HOST }}
+          MODELS: ${{ inputs.models }}
+          PROMPT: ${{ inputs.prompt }}
+          MODE: ${{ inputs.mode }}
+          VERIFY_ALLOW: ${{ inputs.verify_allow }}
+        run: |
+          cd cicd/tests
+          ARGS=(test-mcp)
+          for m in $MODELS; do ARGS+=("$m"); done
+          [ -n "$PROMPT" ] && ARGS+=(--prompt "$PROMPT")
+          case "$MODE" in
+            judge)       ARGS+=(--judge) ;;
+            verify-live) ARGS+=(--verify-live --verify-allow "$VERIFY_ALLOW") ;;
+          esac
+          ARGS+=(-o /tmp/mcp-results.json)
+
+          echo "Models: $MODELS | Mode: $MODE"
+          # The command prints a markdown summary to stdout; tee it into the CI step summary.
+          set -o pipefail
+          npx tsx src/cli.ts "${ARGS[@]}" | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: mcp-results
+          path: /tmp/mcp-results.json

--- a/cicd/tests/testcases/integration/TC-INT-MCP-001.yml
+++ b/cicd/tests/testcases/integration/TC-INT-MCP-001.yml
@@ -1,0 +1,27 @@
+id: TC-INT-MCP-001
+name: MCP tool call returns the server's data
+suite: integration
+goal: A single MCP tool call via mcp-client.ts returns the server's payload
+priority: 5
+timeout: 60000
+dependencies: []
+tags: [mcp]
+
+steps:
+  # Example of the single-tool MCP surface (mcp-client.ts): spawn a stdio MCP
+  # server, call one tool, assert on the result. Here it runs against the bundled
+  # mock server so the example passes with no external service or credentials.
+  # For your project, point MCP_SERVER_COMMAND at your real server.
+  - name: Call get_fact on the bundled mock MCP server
+    command: cd cicd/tests && MCP_SERVER_COMMAND="node_modules/.bin/tsx scripts/mock-mcp-server.ts" npx tsx src/mcp-client.ts get_fact '{}'
+    expectPatterns:
+      - "5500"
+      - "sky is blue"
+    rejectPatterns:
+      - "isError"
+
+criteria: |
+  The mcp-client connects to the MCP server, calls get_fact, and returns the
+  server's payload (the known fact). Verifies the project's MCP wiring end-to-end.
+  This is the single-tool surface; the model-driven loop and the live verifier are
+  the `test-mcp` command (see the README's "MCP tool-call testing" section).

--- a/docs/stories/STORY-006.md
+++ b/docs/stories/STORY-006.md
@@ -69,4 +69,4 @@ to point it at *their* system under test without editing shared code.
 
 - Created: 2026-06-21
 - Plan: #57
-- Issues: ✅ #58 (PR #64), ✅ #59 (PR #65), ✅ #60 (PR #66), #61, #62, #63
+- Issues: ✅ #58 (PR #64), ✅ #59 (PR #65), ✅ #60 (PR #66), ✅ #61 (PR #67), #62, #63


### PR DESCRIPTION
## Summary

- **`.github/workflows/test-mcp.yml`** — reusable (`workflow_call`) + `workflow_dispatch`. Mode = `simple` | `judge` | `verify-live`; keyless agent auth via `CLAUDE_CODE_OAUTH_TOKEN`; MCP server + model runtime wired through repo Variables; the command's markdown summary is tee'd into `$GITHUB_STEP_SUMMARY` and the JSON uploaded as an artifact. Documents the reachable-server/host prerequisite.
- **`testcases/integration/TC-INT-MCP-001.yml`** — example of the single-tool surface (`mcp-client.ts`) that runs against the bundled mock server, so it passes with no external service or creds (`tags: [mcp]`).

Fixes #62
Part of STORY-006 (plan #57)

## Test plan

- [x] Both YAML files parse (js-yaml)
- [x] `npx tsx src/cli.ts run --id TC-INT-MCP-001` → 1 passed / 0 failed
- [x] Testcase needs no external creds (uses the bundled mock server)

Generated with [Claude Code](https://claude.com/claude-code)