### PR TITLE
Sync qa/doc-workflow from upstream; drop the doc-gen-readme workaround

### DIFF
--- a/.claude/commands/doc-workflow/doc-gen-readme.md
+++ b/.claude/commands/doc-workflow/doc-gen-readme.md
@@ -83,7 +83,7 @@ This writes the README only. It does NOT open a PR.
     1. WebSearch "README best practices <year> structure badges diagrams"
     2. Study repo → key ideas: <A>, <B>, <C>
     3. Draft structure; recommend 3 diagrams
-    4. Author docs/diagrams/<idea>.svg → render PNG under docs/diagrams/png/ (a reproducible render step)
+    4. Author <idea>.svg in the project's diagrams dir → render PNG (a reproducible step)
     5. Write README.md; verify tool names / env vars / links against the code
     6. Hand off → /doc-review-readme
 
@@ -91,7 +91,7 @@ This writes the README only. It does NOT open a PR.
 
 ## API Notes
 
-- Reads the repo + the web; writes README.md (+ docs/diagrams/* if diagrams). No PR.
+- Reads the repo + the web; writes README.md (+ the diagrams dir if diagrams). No PR.
 - The WebSearch step is mandatory — it is what keeps this command from going stale.
 - Diagrams are optional; when used, SVG is the source of truth and the PNG is rendered.
 - Producer paired with the review `/doc-review-readme` (see .claude/rules/doc-workflow.md).

--- a/.claude/commands/qa-workflow/qw-cases.md
+++ b/.claude/commands/qa-workflow/qw-cases.md
@@ -32,7 +32,7 @@ Fits in the qa-workflow:
         │
         ├─► Step 2: One file per scenario
         │   - Create docs/tests/TS-NN-<slug>.md with front-matter:
-        │       id, title, namespace, story (+ story_hash = sha256 of the story file),
+        │       id, title, namespace, story (+ the drift anchor the profile declares),
         │       plan: <plan> (the test-plan issue number — omit when there is none),
         │       issue, status: green
         │   - (Format and field meanings: docs/tests/README.md.)
@@ -55,7 +55,9 @@ Fits in the qa-workflow:
 
 - Reuse is optional: if the project has a reuse index, query it for a vetted case or
   step before authoring a near-duplicate, so coverage converges instead of duplicating.
-- `story_hash`: `sha256sum docs/stories/STORY-XXX.md`.
+- Drift anchor: record whatever the profile declares, so a later gate can tell the story
+  has moved (default: `story_hash`, the `sha256sum` of the story file). A project that
+  detects drift another way declares that instead — don't assume hashing.
 - `plan`: the `[STORY-XXX] Test Plan` issue number — the scenario source and the trace
   back (see docs/tests/README.md). Absent for ad-hoc tests written without a plan.
 - Producer paired with `/qw-review-cases`.

--- a/.claude/commands/qa-workflow/qw-review-cases.md
+++ b/.claude/commands/qa-workflow/qw-review-cases.md
@@ -25,7 +25,7 @@ Fits in the qa-workflow:
         ├─► Step 1: Each doc
         │   - [ ] One scenario, one job; cases are coherent slices of it.
         │   - [ ] Front-matter complete and resolvable: story file exists,
-        │         story_hash matches it, namespace set, status present.
+        │         the profile's drift anchor holds, namespace set, status present.
         │   - [ ] Each step's Expected Result is observable — checkable, not vague.
         │   - [ ] Conforms to the format contract (docs/tests/README.md).
         │

--- a/.claude/rules/doc-workflow.md
+++ b/.claude/rules/doc-workflow.md
@@ -20,7 +20,7 @@ in current best practice, leading with the few ideas worth a diagram, and true t
         │                    └─ reuses reviewing-phrasing + reviewing-typography,
         │                       then verifies every claim against the code
         ▼
-   README.md (+ docs/diagrams/* when diagrams help)
+   README.md (+ the project's diagrams dir when diagrams help)
 ```
 
 `doc-gen-readme` opens with a mandatory **WebSearch** step so the structure tracks current
@@ -45,7 +45,7 @@ No producer ships without a review covering its output.
 
 ## Project-specific values
 
-The images dir, the diagram policy (SVG source → PNG), and the README output path are
+The diagrams dir, the diagram policy (SVG source → PNG), and the README output path are
 **not** owned by the `doc-*` commands — they resolve from
 `.claude/rules/project-profile.md`. The values a command shows are the defaults; change
 them in the profile, not the command.

--- a/.claude/rules/project-profile.md
+++ b/.claude/rules/project-profile.md
@@ -30,7 +30,7 @@ owns vs. what it hands off" boundary, made concrete.
 
 - stories dir: `docs/stories/`
 - tests dir: `docs/tests/`
-- images dir: `docs/diagrams/` (SVG source) → `docs/diagrams/png/` (rendered PNG)
+- diagrams dir: `docs/diagrams/` (SVG source) + `docs/diagrams/png/` (rendered)
 - story format contract: `docs/stories/README.md`
 - test format contract: `docs/tests/README.md`
 
@@ -71,7 +71,8 @@ project's choice.
 - test-doc filename: `TS-NN-<slug>.md` in the tests dir
 - front-matter fields: `id, title, namespace, story, story_hash, plan, status`
 - namespace: `test-framework`
-- story hash: `sha256` of the story file (`sha256sum`)
+- drift anchor: `story_hash` — the `sha256` of the story file (`sha256sum`), recorded so
+  `qw-drift` can tell the story has moved.
 - default status: `green` (drift states `stale` | `unbound`, maintained by `qw-drift`)
 
 ## Docs & diagrams
@@ -79,7 +80,7 @@ project's choice.
 - README output: `README.md`
 - diagram policy: SVG source committed under `docs/diagrams/`, rendered to PNG under
   `docs/diagrams/png/` via `make diagrams` (no Mermaid / inline diagram blocks)
-- images dir: `docs/diagrams/` (also under Paths)
+- diagrams dir: `docs/diagrams/` (SVG source) + `docs/diagrams/png/` (rendered) — also under Paths
 
 ## Review semantics
 

--- a/.claude/rules/qa-workflow.md
+++ b/.claude/rules/qa-workflow.md
@@ -52,6 +52,6 @@ The format a test doc must follow is `docs/tests/README.md`.
 ## Project-specific values
 
 The `docs/tests/` path, the `test-plan` label + colour, the `TS-`/`TC-` id schemes, the
-test-doc front-matter fields, the hash algorithm, and the default status are **not** owned
+test-doc front-matter fields, the drift anchor, and the default status are **not** owned
 by the `qw-*` commands — they resolve from `.claude/rules/project-profile.md`. The values
 a command shows are the defaults; change them in the profile, not the command.


### PR DESCRIPTION
## Summary

- Takes `qw-cases`, `qw-review-cases`, `doc-gen-readme` and `rules/doc-workflow.md` from upstream verbatim — all four now match byte-for-byte.
- Drops this repo's local rewrite of `doc-gen-readme`. Upstream hardcoded `docs/images/`, a path that does not exist there, which is why the command had to be patched here; it now defers the location to the profile.
- Renames two profile keys to the names the new units reference: `images dir` → `diagrams dir`, `story hash` → `drift anchor`. The values are unchanged — this repo still resolves to `docs/diagrams/` + `docs/diagrams/png/` and still anchors drift on sha256.
- `rules/dev-workflow.md` keeps its local additions; not part of this sync.

Closes #72

## Test plan

- [ ] The four synced files diff clean against upstream
- [ ] `grep -rn 'images dir' .claude/` returns nothing
- [ ] The profile still declares this repo's real diagram layout

Generated with [Claude Code](https://claude.com/claude-code)