### PR TITLE
make install ships templates/CLAUDE.md, not this repo's own

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,8 +83,8 @@ install: check
 	@# Copy GitHub workflows
 	@cp "$(TEMPLATE_DIR)/.github/workflows/"*.yml "$(TARGET)/.github/workflows/" 2>/dev/null || true
 
-	@# Copy CLAUDE.md if it exists
-	@if [ -f "$(TEMPLATE_DIR)/CLAUDE.md" ]; then cp "$(TEMPLATE_DIR)/CLAUDE.md" "$(TARGET)/CLAUDE.md"; fi
+	@# Copy the adopting project's CLAUDE.md — templates/, not this repo's own
+	@if [ -f "$(TEMPLATE_DIR)/templates/CLAUDE.md" ]; then cp "$(TEMPLATE_DIR)/templates/CLAUDE.md" "$(TARGET)/CLAUDE.md"; fi
 
 	@# Copy Claude skills if they exist
 	@if [ -d "$(TEMPLATE_DIR)/.claude/skills" ]; then \


### PR DESCRIPTION
## Summary

- `Makefile:87` copied `$(TEMPLATE_DIR)/CLAUDE.md`, and `TEMPLATE_DIR` is the repo root — so every project installed with `make install` received *this repo's* maintainer instructions: a §5 opening "the lifecycle this repo owns", a pointer to `plugins/agent-workflows-runner/`, an Agent-skills tail describing this repo's issue tracker and `docs/adr/`, and (since #83) a path to `.claude/commands/dw-test-design.md` that `make install` never creates.
- `templates/CLAUDE.md` existed for exactly this and was consumed by nothing — while still being maintained; it was updated in #83. One line: point the copy at it.

Fixes #84

## Test plan

Verified by running `make install TARGET=<scratch> NAME=demo-project` and inspecting the result, which the issue asked for explicitly ("run and the result inspected, not assumed"):

- [x] Installed `CLAUDE.md` is byte-identical to `templates/CLAUDE.md`
- [x] No repo-specific leakage — no "this repo owns", no `plugins/` path, no `.claude/commands/`, no Agent skills section, no `docs/adr` or `docs/agents`
- [x] §1–4 byte-identical to the `karpathy-guidelines` source they came from
- [x] The only paths it names are the two plugins' own rules, which it describes as something you install
- [x] `build` and `audit-bind` exit 0; `make help` exits 0

No two-axis review on this one: a one-line change verified by running the thing it changes, where `CLAUDE.md` §5 calls extra review passes "ritual, not rigor."

Generated with [Claude Code](https://claude.com/claude-code)