### PR TITLE
Rename the QA lifecycle commands from qw-* to qa-*

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "agent-workflows-runner",
-      "description": "The whole QA lifecycle as slash commands: qw-plan and qw-cases author test docs, qw-bind binds each case to the executable that runs it, and qw-review-bind audits the pair for divergence. Each producer is paired with a review gate; every project-specific value resolves from that project's .claude/rules/project-profile.md. Requires the agent-workflows plugin for the shared report and profile-doctrine rules.",
+      "description": "The whole QA lifecycle as slash commands: qa-plan and qa-cases author test docs, qa-bind binds each case to the executable that runs it, and qa-review-bind audits the pair for divergence. Each producer is paired with a review gate; every project-specific value resolves from that project's .claude/rules/project-profile.md. Requires the agent-workflows plugin for the shared report and profile-doctrine rules.",
       "source": "./plugins/agent-workflows-runner",
       "category": "workflow",
       "homepage": "https://github.com/dogkeeper886/agent-workflows-runner"

--- a/.claude/rules/project-profile.md
+++ b/.claude/rules/project-profile.md
@@ -20,7 +20,7 @@ and the audit. Change a line here and every unit follows.
 
 **What belongs here vs. not.** This file is for **declarative** customization — a value or
 a list. A whole **procedure** (how this runner binds a doc to its YAML, runs the suite, and
-audits the pair) is *not* a value; it lives in the `qw-*` commands and the `cicd/` runner,
+audits the pair) is *not* a value; it lives in the `qa-*` commands and the `cicd/` runner,
 never crammed into a general unit. Lists → here; procedures → a command. This is the rules
 files' "what this owns vs. what it hands off" boundary, made concrete.
 
@@ -72,7 +72,7 @@ project's choice.
 - front-matter fields: `id, title, namespace, spec, plan, status`
 - namespace: `test-framework`
 - spec anchor: the issue number the intent came from — recorded unhashed, traced by a human
-- default status: `green` (the audit's other state is `unbound`, maintained by `qw-review-bind`)
+- default status: `green` (the audit's other state is `unbound`, maintained by `qa-review-bind`)
 
 ## Docs & diagrams
 
@@ -109,12 +109,12 @@ why — is `.claude/rules/agent-report.md`; a unit resolves the wording from her
 
 ## This project's binding + run layer
 
-The `qw-*` commands state the intent; these are the concrete commands behind it here:
+The `qa-*` commands state the intent; these are the concrete commands behind it here:
 
-- bind a case to its executable: `qw-bind` → sets each TC's `Script:` to a
+- bind a case to its executable: `qa-bind` → sets each TC's `Script:` to a
   `cicd/tests/testcases/**/*.yml`
-- audit a binding — the gate: `qw-review-bind` → `npm --prefix cicd/tests run audit-bind` (the
+- audit a binding — the gate: `qa-review-bind` → `npm --prefix cicd/tests run audit-bind` (the
   `Script:` resolves and the doc's step count matches the YAML's, else `unbound`)
-- run the suite (the `qw-run` phase — a phase, not a slash command): `npm test`
+- run the suite (the `qa-run` phase — a phase, not a slash command): `npm test`
 - scaffold a doc from a YAML: `npm --prefix cicd/tests run port-yaml -- <yaml>`
 - reuse index: **none** — reuse is an optional enhancement; it is not present here.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,13 +68,13 @@ human decision (commands suggest the next, they never auto-run it).
 **qa-workflow** is the lifecycle this repo owns — turning a spec into trustworthy tests:
 
 ```
-qw-plan → qw-review-plan → qw-cases → qw-review-cases → qw-bind → qw-review-bind → qw-run
+qa-plan → qa-review-plan → qa-cases → qa-review-cases → qa-bind → qa-review-bind → qa-run
 ```
 
 The commands ship as **this repo's own plugin** (`plugins/agent-workflows-runner/`) —
 install it rather than copying the directory; the full flow + pairing lives in its
-`rules/qa-workflow.md`. `qw-run` is `npm test`, a phase rather than a command, and
-`qw-review-bind`'s audit (`npm --prefix cicd/tests run audit-bind`) is its one gate — it
+`rules/qa-workflow.md`. `qa-run` is `npm test`, a phase rather than a command, and
+`qa-review-bind`'s audit (`npm --prefix cicd/tests run audit-bind`) is its one gate — it
 exits non-zero, though no CI job wires it up yet.
 
 **The dev and doc pipelines come from the upstream `agent-workflows` plugin.** This repo
@@ -91,7 +91,7 @@ doc-gen-readme → doc-review-readme → [human reviews] → PR
 
 Each flow and its producer→review pairing live in that plugin's `rules/dev-workflow.md`
 and `rules/doc-workflow.md`. Trivial work skips the plan: `dw-story → dw-tasks`. The issue
-tracker is shared with the QA lifecycle — one issue gets both `dw-*` (the code) and `qw-*`
+tracker is shared with the QA lifecycle — one issue gets both `dw-*` (the code) and `qa-*`
 (the tests), which anchor their docs to it by number.
 
 `dw-test-design` (after `dw-implement`, before `dw-create-pr` — it writes the tests) is
@@ -149,7 +149,8 @@ See `docs/agents/triage-labels.md`.
 ### Domain docs
 
 Single-context: `CONTEXT.md` + `docs/adr/` at the repo root, created lazily when a term or
-decision actually resolves. `CONTEXT.md` does not exist yet; `docs/adr/` holds ADR-0001.
+decision actually resolves. `CONTEXT.md` does not exist yet; `docs/adr/` holds ADR-0001
+and ADR-0002.
 See `docs/agents/domain.md`.
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # agent-workflows-runner
 
-**The QA half of the [`agent-workflows`](https://github.com/dogkeeper886/agent-workflows) family** — a YAML-driven, dual-judge test framework, plus the `qw-*` commands that author the tests it runs: **a worked example you port into your own repo**, not a package you install unchanged.
+**The QA half of the [`agent-workflows`](https://github.com/dogkeeper886/agent-workflows) family** — a YAML-driven, dual-judge test framework, plus the `qa-*` commands that author the tests it runs: **a worked example you port into your own repo**, not a package you install unchanged.
 
-This repo owns the whole QA lifecycle — plan, author, bind, audit, run. `agent-workflows` keeps the **ship tail** (branch → PR → merge), the **report contract**, and the review skills; the `qw-*` commands cite two of its rules, so it is a prerequisite rather than an alternative. Neither is complete alone.
+This repo owns the whole QA lifecycle — plan, author, bind, audit, run. `agent-workflows` keeps the **ship tail** (branch → PR → merge), the **report contract**, and the review skills; the `qa-*` commands cite two of its rules, so it is a prerequisite rather than an alternative. Neither is complete alone.
 
 Testing here is fast and deterministic by default (the simple judge), with an opt-in agent judge as a second opinion — an Agent Client Protocol client that runs **keyless on a Claude Code subscription**, so no Console API key is needed and swapping the model or vendor is just configuration.
 
@@ -307,13 +307,13 @@ Drive it in CI with `.github/workflows/test-mcp.yml` (`mode: simple | judge | ve
 
 The tooling splits three ways — a **plugin you install**, skills **copied into your project** by `/install`, and the **maintainer tooling** this repo is built with.
 
-### The QA lifecycle plugin — `qw-*`
+### The QA lifecycle plugin — `qa-*`
 
 The commands that turn a spec into trustworthy tests ship as a Claude Code plugin, from this repo's own marketplace. Installing beats copying: a plugin update moves every project at once, where a copied `.claude/` directory leaves each repo on its own fork.
 
 ```bash
 # Prerequisite: agent-workflows, whose agent-report and profile-doctrine rules
-# the qw-* commands cite. Claude Code can't express a dependency between plugins.
+# the qa-* commands cite. Claude Code can't express a dependency between plugins.
 /plugin marketplace add dogkeeper886/agent-workflows
 /plugin install agent-workflows@agent-workflows
 
@@ -323,9 +323,9 @@ The commands that turn a spec into trustworthy tests ship as a Claude Code plugi
 
 | Producer → review | What the pair covers |
 |-------------------|----------------------|
-| `/qw-plan` → `/qw-review-plan` | what to test — scenarios persisted as a `[#<spec>] Test Plan` issue |
-| `/qw-cases` → `/qw-review-cases` | the test docs in `docs/tests/` (the [format contract](docs/tests/README.md)) |
-| `/qw-bind` → `/qw-review-bind` | each case bound to the YAML that runs it — the audit is the gate, exiting non-zero for CI |
+| `/qa-plan` → `/qa-review-plan` | what to test — scenarios persisted as a `[#<spec>] Test Plan` issue |
+| `/qa-cases` → `/qa-review-cases` | the test docs in `docs/tests/` (the [format contract](docs/tests/README.md)) |
+| `/qa-bind` → `/qa-review-bind` | each case bound to the YAML that runs it — the audit is the gate, exiting non-zero for CI |
 
 No producer ships without its review. Project-specific values — paths, labels, id schemes — resolve from your `.claude/rules/project-profile.md`, never from the commands.
 
@@ -392,7 +392,7 @@ This runner is one of three repos (see the diagram up top):
 | Repo | Role | Status |
 |------|------|--------|
 | [**agent-workflows**](https://github.com/dogkeeper886/agent-workflows) | the ship tail (branch → PR → merge), the report contract, and the review skills — a prerequisite of this repo's plugin | shipped |
-| **agent-workflows-runner** (this repo) | the whole QA lifecycle: the `qw-*` commands that plan, author and bind test docs, and the dual-judge framework that runs them | shipped |
+| **agent-workflows-runner** (this repo) | the whole QA lifecycle: the `qa-*` commands that plan, author and bind test docs, and the dual-judge framework that runs them | shipped |
 | **agent-studio** | local-first web GUI over the workflows + runner; closes the Dev → QA → PM loop | working name (currently `ai-qa-studio`), planning |
 
 ## License

--- a/cicd/tests/src/audit-bind.ts
+++ b/cicd/tests/src/audit-bind.ts
@@ -37,7 +37,7 @@ export interface BindFinding {
  * This is a structural signal: equal counts mean "same number of steps", not
  * "same steps" — a count-preserving edit (swap/reorder) stays `bound`. That is
  * the floor for an audit-not-codegen design; semantic agreement is the
- * reviewer's job in /qw-review-bind.
+ * reviewer's job in /qa-review-bind.
  */
 function yamlStepCount(path: string): number {
   let inSteps = false;

--- a/cicd/tests/src/port-yaml.ts
+++ b/cicd/tests/src/port-yaml.ts
@@ -5,7 +5,7 @@
  * executable that already exists, so the in-repo apparatus gets its canonical
  * half without re-authoring it. The output is a scaffold: it carries the steps
  * and the `Script:` binding; the objective, expected results, and spec anchor
- * are TODOs for a human/agent to fill, then `qw-review-bind` audits the result.
+ * are TODOs for a human/agent to fill, then `qa-review-bind` audits the result.
  *
  * Run: npm run port-yaml -- cicd/tests/testcases/integration/TC-INT-MCP-001.yml > docs/tests/TS-NN-slug.md
  */

--- a/docs/adr/0001-dw-test-design-stays-in-this-repo.md
+++ b/docs/adr/0001-dw-test-design-stays-in-this-repo.md
@@ -10,7 +10,7 @@ We keep it here and move it flat, to `.claude/commands/dw-test-design.md`.
 ## Considered Options
 
 - **Move it into `plugins/agent-workflows-runner/commands/`** — this repo's own plugin,
-  and the candidate the ticket named. Rejected: that plugin's stated job is the `qw-*` QA
+  and the candidate the ticket named. Rejected: that plugin's stated job is the `qa-*` QA
   lifecycle, and a `dw-*` command inside it would be a second job. The command also
   references `/dw-implement` and `/dw-create-pr`, which ship from a *different* plugin —
   shipping it here would hand every installing project a command whose chain has a

--- a/docs/adr/0002-rename-qw-commands-to-qa.md
+++ b/docs/adr/0002-rename-qw-commands-to-qa.md
@@ -1,0 +1,65 @@
+# Rename the QA lifecycle commands from `qw-*` to `qa-*`
+
+`qw-` abbreviated `qa-workflow`, and dated from when the commands lived in a
+`.claude/commands/qa-workflow/` directory. That directory is gone — the commands ship from
+this repo's plugin now — and `qw-` was the last survivor of a naming scheme its own author
+has moved off.
+
+The six commands become `qa-plan`, `qa-review-plan`, `qa-cases`, `qa-review-cases`,
+`qa-bind`, `qa-review-bind`. The `qa-run` phase follows.
+
+## The precedent this follows
+
+`agent-workflows#135` renamed `dw-create-pr` / `dw-merge` to `ship-create-pr` /
+`ship-merge`, after `#123` deleted the seven `dw-*` commands that competed with
+`mattpocock/skills`. Its reasoning gives two rules, and both decide this:
+
+1. **A prefix must name something that still exists**, and should name what the commands
+   *do* — not where they used to live, and not what ships them. `dw-` named a deleted
+   pipeline, so it "named nothing."
+2. **Keep a prefix.** They explicitly rejected bare `/merge` and `/create-pr`: the
+   unqualified form is invocable, so a command lands in a shared namespace already holding
+   things like `resolving-merge-conflicts`. A prefix also keeps the group clustered in the
+   `/` menu.
+
+## Considered Options
+
+- **Keep `qw-`.** Rejected. It is an opaque abbreviation — `dw-` and `doc-` at least
+  gesture at "dev" and "doc"; nothing about `qw-` says QA to someone who has not read the
+  docs. It also no longer matches any sibling: upstream ships `doc-*` and `ship-*`.
+- **Rename to the repo name, `agent-workflows-runner-*`.** Rejected. Claude Code already
+  namespaces plugin commands as `<plugin>:<command>`, so this yields
+  `/agent-workflows-runner:agent-workflows-runner-plan` — the prefix stated twice, and 30
+  characters before the word carrying the meaning. `profile-doctrine.md`'s `<repo-name>-`
+  rule is scoped to a project's *own* units, "ones no other project wants"; these are the
+  shared ones, shipped to every consuming project. And #135 chose `ship-`, four characters
+  naming a job, over `agent-workflows-create-pr`.
+- **Drop the prefix — `/plan`, `/cases`, `/bind`.** Rejected for the reason #135 gives:
+  the bare form is invocable, and those names are far too generic for a shared namespace.
+- **`qa-`.** Chosen. Short, a real word, and it names the discipline the commands serve —
+  the same virtue `ship-` has. It matches `rules/qa-workflow.md`, which every one of these
+  commands cites as its first line of doctrine.
+
+## Consequences
+
+**It resolves a live collision from our side.** Both plugins are installed at user scope
+and both currently ship `qw-cases`, `qw-plan`, `qw-review-cases` and `qw-review-plan` —
+verified with `claude plugin details` on each. That is ADR-0002 of the upstream repo
+(`complement-mattpocock-skills`) mid-landing: it moves the QA authoring half here, and
+upstream keeps its copies until `agent-workflows#128` removes them. Renaming clears the
+overlap without waiting on another repo. **#128 is still the other half** — this decision
+does not close it.
+
+**No ASCII realignment was needed.** `qw-` and `qa-` are both three characters, so every
+diagram and aligned comment column survives the rename untouched. #135 had to realign by
+hand because `dw-` → `ship-` grew by two.
+
+**Discovery rests on the prefix.** The `/` menu is where a user meets these commands, and
+typing `/qa` filters to the family. The qualified `<plugin>:<command>` form is for
+disambiguation, not browsing. The per-command description the menu shows is each file's H1
+heading — these commands carry no front-matter `description:` — so the H1s remain the only
+per-command prose a user reads.
+
+**`docs/stories/` keeps the old names.** STORY-005 still says `qw-bind`, `qw-review-bind`,
+`qw-drift`; those records describe what was true when written, and `qw-drift` names a
+command deleted long since. The same call #135 made for its two completed stories.

--- a/docs/tests/README.md
+++ b/docs/tests/README.md
@@ -2,10 +2,10 @@
 
 Each test is a **readable markdown document** that lives here, close to the spec it verifies.
 The markdown owns **why / what** (intent); the bound `cicd/` YAML owns **how it runs**
-(execution). `qw-bind` links them and `qw-review-bind` audits the link — via
+(execution). `qa-bind` links them and `qa-review-bind` audits the link — via
 `npm --prefix cicd/tests` (`audit-bind` / `port-yaml`).
 
-This file is the format contract, defined once and here: the `qw-*` commands ship in this
+This file is the format contract, defined once and here: the `qa-*` commands ship in this
 repo's own plugin (`plugins/agent-workflows-runner/`) and resolve this path from
 `.claude/rules/project-profile.md` → Paths.
 
@@ -34,7 +34,7 @@ title: Stack builds and runs its lifecycle
 namespace: test-framework       # which repo/tenant this test belongs to
 spec: 76                        # the issue this scenario's intent came from
 plan: 28                        # the [#<spec>] Test Plan issue it was authored from (optional)
-status: green                   # green | unbound  (maintained by qw-review-bind)
+status: green                   # green | unbound  (maintained by qa-review-bind)
 ---
 ```
 
@@ -63,9 +63,9 @@ and the row count is what `audit-bind` compares to the YAML's `steps:`.
 
 ## Binding, running, auditing
 
-- **Bind** (`qw-bind`): set each TC's `Script:` to the `cicd/tests/testcases/**/*.yml` that runs
+- **Bind** (`qa-bind`): set each TC's `Script:` to the `cicd/tests/testcases/**/*.yml` that runs
   it. Or revert: `npm --prefix cicd/tests run port-yaml -- <yaml>` scaffolds a doc from a YAML.
-- **Audit** (`qw-review-bind`): `npm --prefix cicd/tests run audit-bind` — the `Script:` resolves
+- **Audit** (`qa-review-bind`): `npm --prefix cicd/tests run audit-bind` — the `Script:` resolves
   and the step counts match, else `unbound`. Exits non-zero, so a CI job can gate on it.
 - **Run**: `npm test` (the cicd assert-first runner).
 

--- a/plugins/agent-workflows-runner/.claude-plugin/plugin.json
+++ b/plugins/agent-workflows-runner/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "agent-workflows-runner",
-  "description": "The QA lifecycle (qw-*): plan what to test, author the test docs, bind each case to its executable, and audit the pair. Doctrine travels in this plugin; a project's values stay in that project's .claude/rules/project-profile.md. Prerequisite: the agent-workflows plugin, whose report and profile-doctrine rules these commands cite.",
+  "description": "The QA lifecycle (qa-*): plan what to test, author the test docs, bind each case to its executable, and audit the pair. Doctrine travels in this plugin; a project's values stay in that project's .claude/rules/project-profile.md. Prerequisite: the agent-workflows plugin, whose report and profile-doctrine rules these commands cite.",
   "author": {
     "name": "dogkeeper886"
   },

--- a/plugins/agent-workflows-runner/commands/qa-bind.md
+++ b/plugins/agent-workflows-runner/commands/qa-bind.md
@@ -22,12 +22,12 @@ Target: a docs/tests/TS-*.md scenario, or an executable to port.
 
 Binding is **audit, not codegen**: the markdown owns *intent* (why / what), the
 executable owns *execution* (how it runs). This command establishes the link between
-them; its paired review `/qw-review-bind` checks the link still holds.
+them; its paired review `/qa-review-bind` checks the link still holds.
 
 Fits in the qa-workflow:
 
-    qw-plan → qw-review-plan → qw-cases → qw-review-cases → qw-bind → qw-review-bind → qw-run
-    (qw-run = `npm test` — the project's runner; a phase, not a slash command)
+    qa-plan → qa-review-plan → qa-cases → qa-review-cases → qa-bind → qa-review-bind → qa-run
+    (qa-run = `npm test` — the project's runner; a phase, not a slash command)
 
 ---
 
@@ -35,17 +35,17 @@ Fits in the qa-workflow:
 
 ### A. Forward — bind an existing test doc
 
-    /qw-bind docs/tests/TS-01-stack-lifecycle.md
+    /qa-bind docs/tests/TS-01-stack-lifecycle.md
         │
         ├─► For each `### TC-NN:` case, set a `Script:` line to the executable that
         │   runs it (e.g. cicd/tests/testcases/integration/TC-INTEGRATION-001.yml).
         ├─► Keep the case's Steps table aligned 1:1 with the executable's steps — the
         │   audit treats a step-count mismatch as `unbound`.
-        └─► Run `/qw-review-bind` to confirm the binding.
+        └─► Run `/qa-review-bind` to confirm the binding.
 
 ### B. Revert — port an executable into a doc scaffold
 
-    /qw-bind cicd/tests/testcases/build/TC-BUILD-001.yml
+    /qa-bind cicd/tests/testcases/build/TC-BUILD-001.yml
         │
         ├─► Generate a scaffold from the executable — the project declares the scaffolder
         │   (project-profile → binding + run layer). Here:
@@ -54,7 +54,7 @@ Fits in the qa-workflow:
         │   expected results, spec anchor, and namespace are TODOs.
         ├─► Fill the TODOs: `namespace`, `spec` (the issue the intent came from), each
         │   TC's objective and Expected Result column. (Format contract: project-profile → Paths.)
-        └─► Run `/qw-review-bind` to confirm the binding, then `/qw-review-cases` for meaning.
+        └─► Run `/qa-review-bind` to confirm the binding, then `/qa-review-cases` for meaning.
 
 ---
 
@@ -69,5 +69,5 @@ and a section with nothing to report says so.
 
 - `port-yaml` is a scaffolder, not a translator — a human/agent fills meaning.
 - The binding + audit commands are project values — see project-profile.
-- Producer paired with `/qw-review-bind` (the audit).
+- Producer paired with `/qa-review-bind` (the audit).
 ```

--- a/plugins/agent-workflows-runner/commands/qa-cases.md
+++ b/plugins/agent-workflows-runner/commands/qa-cases.md
@@ -16,7 +16,7 @@ Values — this project's:
 Turn a reviewed test plan into readable test docs in docs/tests/ — reusing vetted
 steps where a reuse index is available, instead of re-inventing them.
 
-Target: the reviewed `[#<spec>] Test Plan` issue from `/qw-review-plan` (its scenarios).
+Target: the reviewed `[#<spec>] Test Plan` issue from `/qa-review-plan` (its scenarios).
 
 ## PURPOSE
 
@@ -27,19 +27,19 @@ Action / Expected Result rows.
 
 Fits in the qa-workflow:
 
-    qw-plan → qw-review-plan → qw-cases → qw-review-cases → qw-bind → qw-review-bind → qw-run
+    qa-plan → qa-review-plan → qa-cases → qa-review-cases → qa-bind → qa-review-bind → qa-run
 
 ---
 
 ## WORKFLOW
 
-    /qw-cases 76
+    /qa-cases 76
         │
         ├─► Step 1: Read the test-plan issue
         │   - Find it (`test-plan` is qa's own label — distinct from dev's `plan`):
         │       gh issue list --search "[#<spec>] Test Plan" --label test-plan --state all
         │     Read its scenarios; note its number <plan>. (No plan issue → the scenarios
-        │     came from /qw-plan in chat; <plan> is absent.)
+        │     came from /qa-plan in chat; <plan> is absent.)
         │
         ├─► Step 2: One file per scenario
         │   - Create docs/tests/TS-NN-<slug>.md with front-matter:
@@ -55,9 +55,9 @@ Fits in the qa-workflow:
         │   - Fill the Steps table: each row one Action + its Expected Result.
         │
         └─► Step 4: Hand off
-            - Run `/qw-review-cases` to gate the docs.
-            - Reviewed docs then go to `/qw-bind` — bind each case to its executable, then
-              `/qw-review-bind` and run. (If a reuse index exists, the new docs get indexed
+            - Run `/qa-review-cases` to gate the docs.
+            - Reviewed docs then go to `/qa-bind` — bind each case to its executable, then
+              `/qa-review-bind` and run. (If a reuse index exists, the new docs get indexed
               there.)
 
 ---
@@ -79,5 +79,5 @@ report says so.
   did would need a network call.
 - `plan`: the `[#<spec>] Test Plan` issue number — the scenario source and the trace
   back. Absent for ad-hoc tests written without a plan.
-- Producer paired with `/qw-review-cases`.
+- Producer paired with `/qa-review-cases`.
 ```

--- a/plugins/agent-workflows-runner/commands/qa-plan.md
+++ b/plugins/agent-workflows-runner/commands/qa-plan.md
@@ -23,18 +23,18 @@ Target: the spec issue the tests exist for, or an ad-hoc request ("write a test 
 The front of the qa-workflow — the test analogue of reading a spec before
 implementing. It produces a short list of **scenarios** (each a TS-to-be) that together
 cover the need, and **persists them as a `[#<spec>] Test Plan` GitHub issue** so the plan
-survives the session and `qw-review-plan` reviews a real artifact (not a chat message);
-`qw-cases` then writes against it. See `qa-workflow.md`.
+survives the session and `qa-review-plan` reviews a real artifact (not a chat message);
+`qa-cases` then writes against it. See `qa-workflow.md`.
 
 Fits in the qa-workflow:
 
-    qw-plan → qw-review-plan → qw-cases → qw-review-cases → qw-bind → qw-review-bind → qw-run
+    qa-plan → qa-review-plan → qa-cases → qa-review-cases → qa-bind → qa-review-bind → qa-run
 
 ---
 
 ## WORKFLOW
 
-    /qw-plan 76
+    /qa-plan 76
         │
         ├─► Step 1: Read the need
         │   - If a spec issue: read it (the problem, the stories, what success looks like):
@@ -53,7 +53,7 @@ Fits in the qa-workflow:
         ├─► Step 3: Propose scenarios
         │   - Break the need into scenarios (TS-to-be), each:
         │     • one coherent slice of behaviour, • independently runnable,
-        │     • mappable to one or more of the project's executables (bound later, by qw-bind).
+        │     • mappable to one or more of the project's executables (bound later, by qa-bind).
         │   - For each, name the cases (TC-to-be) it will hold, at a sentence each.
         │
         ├─► Step 4: Open the test-plan issue
@@ -65,8 +65,8 @@ Fits in the qa-workflow:
         │       gh issue create --label "test-plan" --title "[#<spec>] Test Plan" --body "…"
         │
         └─► Step 5: Hand off — stop for review
-            - Show the test-plan issue URL for `/qw-review-plan`, then `/qw-cases`.
-            - STOP. Do NOT write TS docs — that is `/qw-cases`.
+            - Show the test-plan issue URL for `/qa-review-plan`, then `/qa-cases`.
+            - STOP. Do NOT write TS docs — that is `/qa-cases`.
 
 ---
 
@@ -92,10 +92,10 @@ The test-plan issue. Trace carries its URL; Next is the paired review. Reported 
 
 ## API Notes
 
-- A scenario here is a *plan item*, not yet a file — `qw-cases` writes the doc.
+- A scenario here is a *plan item*, not yet a file — `qa-cases` writes the doc.
 - The scenarios persist as a `[#<spec>] Test Plan` issue (label `test-plan`; ad-hoc →
   `Test Plan: <subject>`) — the same plan-as-issue form `dev-workflow` uses, with its own
   `test-plan` label so it never collides with dev's plan issues (label `plan`).
 - The spec is the goal; keep the plan to coverage, not step detail.
-- Producer paired with `/qw-review-plan`, which reviews the issue.
+- Producer paired with `/qa-review-plan`, which reviews the issue.
 ```

--- a/plugins/agent-workflows-runner/commands/qa-review-bind.md
+++ b/plugins/agent-workflows-runner/commands/qa-review-bind.md
@@ -20,7 +20,7 @@ Target: the docs/tests/ scenarios (all, or one named file).
 
 ## PURPOSE
 
-The paired review for `/qw-bind`, and the qa-workflow's one gate: binding is
+The paired review for `/qa-bind`, and the qa-workflow's one gate: binding is
 audit-not-codegen, so something has to *check* that the markdown and the executable
 haven't drifted apart. Divergence is silent until something looks; this looks,
 deterministically, in CI and on demand. It runs the audit and adds a human/agent pass
@@ -28,14 +28,14 @@ for meaning.
 
 Fits in the qa-workflow:
 
-    qw-plan → qw-review-plan → qw-cases → qw-review-cases → qw-bind → qw-review-bind → qw-run
-    (qw-run = `npm test` — the project's runner; a phase, not a slash command)
+    qa-plan → qa-review-plan → qa-cases → qa-review-cases → qa-bind → qa-review-bind → qa-run
+    (qa-run = `npm test` — the project's runner; a phase, not a slash command)
 
 ---
 
 ## WORKFLOW
 
-    /qw-review-bind
+    /qa-review-bind
         │
         ├─► Step 1: Run the deterministic audit
         │   The project declares which command that is — see project-profile → binding + run
@@ -72,5 +72,5 @@ first, and a section with nothing to report says so.
 - `unbound` is one of the test doc's `status` values (see the format contract).
 - A test doc's `spec` anchor is a trace for a human, not a signal this gate reads —
   resolving it would put a network call in a CI check.
-- Review paired with the producer `/qw-bind`.
+- Review paired with the producer `/qa-bind`.
 ```

--- a/plugins/agent-workflows-runner/commands/qa-review-cases.md
+++ b/plugins/agent-workflows-runner/commands/qa-review-cases.md
@@ -16,21 +16,21 @@ Values — this project's:
 Check each test doc does one clear job, has observable steps, and traces back to
 its spec — before it is bound and run.
 
-Target: the docs/tests/TS-*.md docs written by /qw-cases for a spec.
+Target: the docs/tests/TS-*.md docs written by /qa-cases for a spec.
 
 ## PURPOSE
 
-The paired review for `/qw-cases`. Gates the written docs for quality and traceability.
+The paired review for `/qa-cases`. Gates the written docs for quality and traceability.
 
 Fits in the qa-workflow:
 
-    qw-plan → qw-review-plan → qw-cases → qw-review-cases → qw-bind → qw-review-bind → qw-run
+    qa-plan → qa-review-plan → qa-cases → qa-review-cases → qa-bind → qa-review-bind → qa-run
 
 ---
 
 ## WORKFLOW
 
-    /qw-review-cases 76
+    /qa-review-cases 76
         │
         ├─► Step 1: Each doc
         │   - [ ] One scenario, one job; cases are coherent slices of it.
@@ -44,7 +44,7 @@ Fits in the qa-workflow:
         │   - [ ] No duplicate of an existing scenario for the same spec.
         │
         └─► Step 3: Decision
-            - PASS: docs do their job and trace back → hand off to `/qw-bind`.
+            - PASS: docs do their job and trace back → hand off to `/qa-bind`.
             - REVISE: fix the named doc — smallest change first — and re-check.
 
 ---
@@ -58,7 +58,7 @@ with nothing to report says so.
 
 ## API Notes
 
-- This reviews the *doc* (intent); the doc↔script binding is reviewed in `/qw-review-bind`.
+- This reviews the *doc* (intent); the doc↔script binding is reviewed in `/qa-review-bind`.
 - Published-deliverable phrasing/typography is out of scope here.
-- Review paired with the producer `/qw-cases`.
+- Review paired with the producer `/qa-cases`.
 ```

--- a/plugins/agent-workflows-runner/commands/qa-review-plan.md
+++ b/plugins/agent-workflows-runner/commands/qa-review-plan.md
@@ -16,28 +16,28 @@ Values — this project's:
 Check the proposed scenarios cover the spec — and stay coverage, not a frozen
 step-by-step spec of their own.
 
-Target: the `[#<spec>] Test Plan` issue written by `/qw-plan` (label `test-plan`).
+Target: the `[#<spec>] Test Plan` issue written by `/qa-plan` (label `test-plan`).
 
 ## PURPOSE
 
-The paired review for `/qw-plan`. Gates the persisted **test-plan issue** before
-`qw-cases` writes any docs, so coverage gaps are caught cheaply. See `qa-workflow.md`.
+The paired review for `/qa-plan`. Gates the persisted **test-plan issue** before
+`qa-cases` writes any docs, so coverage gaps are caught cheaply. See `qa-workflow.md`.
 
 Fits in the qa-workflow:
 
-    qw-plan → qw-review-plan → qw-cases → qw-review-cases → qw-bind → qw-review-bind → qw-run
+    qa-plan → qa-review-plan → qa-cases → qa-review-cases → qa-bind → qa-review-bind → qa-run
 
 ---
 
 ## WORKFLOW
 
-    /qw-review-plan 76
+    /qa-review-plan 76
         │
         ├─► Step 1: Read the test-plan issue
         │   - Find it (`test-plan` is qa's own label — distinct from dev's `plan`):
         │       gh issue list --search "[#<spec>] Test Plan" --label test-plan --state all
         │     (ad-hoc target: search "Test Plan: <subject>"). Read its scenarios.
-        │   - If none exists, report and stop (run `/qw-plan` first).
+        │   - If none exists, report and stop (run `/qa-plan` first).
         │
         ├─► Step 2: Coverage vs the spec
         │   - [ ] Every item in the spec's success criteria maps to a scenario.
@@ -51,8 +51,8 @@ Fits in the qa-workflow:
         │
         └─► Step 4: Decision (recorded on the issue)
             - PASS: covers the spec → comment "Reviewed — covers the spec" on the issue;
-              proceed to `/qw-cases`.
-            - REVISE: comment the missing or excess scenario on the issue; back to `/qw-plan`.
+              proceed to `/qa-cases`.
+            - REVISE: comment the missing or excess scenario on the issue; back to `/qa-plan`.
 
 ---
 
@@ -65,7 +65,7 @@ the verdict first, and a section with nothing to report says so.
 
 ## API Notes
 
-- Coverage gate only — step detail is `qw-cases`/`qw-review-cases`'s job.
-- Review paired with the producer `/qw-plan`; it gates the persisted
+- Coverage gate only — step detail is `qa-cases`/`qa-review-cases`'s job.
+- Review paired with the producer `/qa-plan`; it gates the persisted
   `[#<spec>] Test Plan` issue, recording PASS/REVISE as a comment on it.
 ```

--- a/plugins/agent-workflows-runner/rules/qa-workflow.md
+++ b/plugins/agent-workflows-runner/rules/qa-workflow.md
@@ -11,23 +11,23 @@ diverging.
    the spec issue the tests exist for   ──or──  "write a test for X"   (on request)
             │
             ▼
-   qw-plan ───────► qw-review-plan      what to test — scenarios persisted as the
+   qa-plan ───────► qa-review-plan      what to test — scenarios persisted as the
             │                            [#<spec>] Test Plan issue
             ▼
-   qw-cases ──────► qw-review-cases     write docs/tests/TS-*.md (the format contract)
+   qa-cases ──────► qa-review-cases     write docs/tests/TS-*.md (the format contract)
             │
             ▼
-   qw-bind ───────► qw-review-bind      bind each case to its executable, then audit
+   qa-bind ───────► qa-review-bind      bind each case to its executable, then audit
             │                            the pair — the gate, exiting non-zero for CI
             ▼
-   qw-run                               run the suite (the project's runner — see
+   qa-run                               run the suite (the project's runner — see
                                          project-profile). A phase, not a slash command.
 ```
 
 ## The test-plan issue
 
-`qw-plan`'s scenarios persist as a **GitHub issue**, titled `[#<spec>] Test Plan`, labelled
-`test-plan` (distinct from dev's `Plan`). `qw-review-plan` reviews it; `qw-cases` reads it and
+`qa-plan`'s scenarios persist as a **GitHub issue**, titled `[#<spec>] Test Plan`, labelled
+`test-plan` (distinct from dev's `Plan`). `qa-review-plan` reviews it; `qa-cases` reads it and
 records the issue number in each `TS-*.md` `plan:` field. Nothing auto-closes it — no change
 request targets a test plan — so close it by hand once its docs have landed.
 
@@ -35,9 +35,9 @@ request targets a test plan — so close it by hand once its docs have landed.
 
 | Producer | Review | Covers |
 |----------|--------|--------|
-| `qw-plan`  | `qw-review-plan`  | does the plan cover the spec? |
-| `qw-cases` | `qw-review-cases` | each doc: one job, observable, traces back |
-| `qw-bind`  | `qw-review-bind`  | doc ↔ executable still agree, else `unbound` |
+| `qa-plan`  | `qa-review-plan`  | does the plan cover the spec? |
+| `qa-cases` | `qa-review-cases` | each doc: one job, observable, traces back |
+| `qa-bind`  | `qa-review-bind`  | doc ↔ executable still agree, else `unbound` |
 
 No producer ships without a review covering its output.
 
@@ -75,7 +75,7 @@ install steps name it.
 
 The `docs/tests/` path, the `test-plan` label + colour, the `TS-`/`TC-` id schemes, the test-doc
 front-matter fields, the default status, and the binding + audit commands are **not** owned by the
-`qw-*` units. They resolve from `.claude/rules/project-profile.md`. The values a command shows are
+`qa-*` units. They resolve from `.claude/rules/project-profile.md`. The values a command shows are
 the defaults; change them in the profile, not the command.
 
 The `gh` invocations in these commands are that kind of illustrated default — the profile declares

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -67,7 +67,7 @@ human decision (commands suggest the next, they never auto-run it).
 
 These pipelines are **plugins you install** — nothing here ships them, and none of their
 commands exist in this project until you do. `agent-workflows` carries the dev and doc
-pipelines; `agent-workflows-runner` carries the `qw-*` QA lifecycle and requires it:
+pipelines; `agent-workflows-runner` carries the `qa-*` QA lifecycle and requires it:
 
 ```bash
 /plugin marketplace add dogkeeper886/agent-workflows
@@ -88,7 +88,7 @@ dw-story → dw-review-story → dw-plan → [human reviews the plan issue]
 **qa-workflow** — a spec into trustworthy tests:
 
 ```
-qw-plan → qw-review-plan → qw-cases → qw-review-cases → qw-bind → qw-review-bind → qw-run
+qa-plan → qa-review-plan → qa-cases → qa-review-cases → qa-bind → qa-review-bind → qa-run
 ```
 
 **doc-workflow** — a codebase into its README:
@@ -100,8 +100,8 @@ doc-gen-readme → doc-review-readme → [human reviews] → PR
 Each flow and its producer→review pairing live in the rules of the plugin that ships it —
 `rules/dev-workflow.md` and `rules/doc-workflow.md` in `agent-workflows`,
 `rules/qa-workflow.md` in `agent-workflows-runner`. Trivial work skips the plan:
-`dw-story → dw-tasks`. `qw-run` is `npm test`, a phase rather than a command, and
-`qw-review-bind`'s audit (`npm --prefix cicd/tests run audit-bind`) is the one gate — it
+`dw-story → dw-tasks`. `qa-run` is `npm test`, a phase rather than a command, and
+`qa-review-bind`'s audit (`npm --prefix cicd/tests run audit-bind`) is the one gate — it
 exits non-zero, so wire it into CI if you want it to fail a build.
 
 Two review gates are external skills these plugins do not own — invoke them by hand:


### PR DESCRIPTION
## Summary

- `qw-` abbreviated `qa-workflow` and dated from a `.claude/commands/qa-workflow/` directory that no longer exists. The six commands become `qa-plan`, `qa-review-plan`, `qa-cases`, `qa-review-cases`, `qa-bind`, `qa-review-bind`; the `qa-run` phase follows.
- Follows `agent-workflows#135` (`dw-*` → `ship-*`), which gives the two rules: a prefix must name something that still exists and should name what the commands *do*, and a prefix stays — the bare form is invocable, so `/plan` and `/bind` would be far too generic. `qa-` mirrors `ship-`: short, a real word, matching `rules/qa-workflow.md` that every command cites first.
- **Resolves a live collision from our side.** Both installed plugins shipped `qw-cases`, `qw-plan`, `qw-review-cases`, `qw-review-plan`. After this, a set comparison of the two plugins' command names is empty. `agent-workflows#128` is the other half and stays open.

Fixes #87

## Notes for the reviewer

- **ADR-0002** records the decision, including why `agent-workflows-runner-*` was rejected: plugin commands are already namespaced `<plugin>:<command>`, so it reads `/agent-workflows-runner:agent-workflows-runner-plan`, and `profile-doctrine`'s `<repo-name>-` rule covers a project's *own* units, not the shared ones.
- **No ASCII realignment needed** — `qw-` and `qa-` are both three characters, so every flow diagram and aligned comment column survives untouched. #135 had to realign by hand because `dw-` → `ship-` grew by two.
- **`docs/stories/STORY-005.md` deliberately keeps the old names** and is byte-identical to `main`. Completed story records describe what was true when written, and `qw-drift` names a command deleted long ago — renaming it would invent a name that never existed. Same call #135 made for its two completed stories.
- No executable code changed: the two `.ts` edits are comment-only, the two manifest edits are description strings.

## Test plan

- [x] `build` exit 0 · `npm test` exit 0 (1 passed) · `audit-bind` exit 0 · `check:verifier` / `check:mcp-host` / `check:mcp-test` all exit 0 · `make help` exit 0
- [x] Repo-wide grep leaves `qw-` only in `STORY-005` (history) and ADR-0002 (which is about the rename)
- [x] All 18 changed files read line by line — no semantic damage from the substitution
- [x] `claude plugin update` → `2831772e5db0` → `c795cae562cb`; `claude plugin details` lists the six `qa-*` commands
- [x] `/agent-workflows:reviewing-finish` → PASS
- [ ] `/code-review-2axis` **not run** — mechanical rename, no executable code changed; skipped by maintainer decision

Generated with [Claude Code](https://claude.com/claude-code)