### PR TITLE
docs(#96): name the binding + run layer section one way

### DIFF
--- a/plugins/agent-workflows-runner/skills/setup-agent-runner/SKILL.md
+++ b/plugins/agent-workflows-runner/skills/setup-agent-runner/SKILL.md
@@ -37,7 +37,8 @@ bind here: own only what you read, add or update in place and never truncate, an
 already there as a decision rather than something to overwrite.
 
 The sections this plugin owns, and nothing else:
-**Paths · ID schemes · Front-matter & format contract · Connected flow · Binding + run layer.**
+**Paths · ID schemes · Front-matter & format contract · Connected flow · This project's binding
++ run layer.**
 See [profile-sections.md](./profile-sections.md).
 
 If `agent-workflows` is also placed, its sections — Labels, Linking & branch, Platform, Git,

--- a/plugins/agent-workflows-runner/skills/setup-agent-runner/profile-sections.md
+++ b/plugins/agent-workflows-runner/skills/setup-agent-runner/profile-sections.md
@@ -15,7 +15,7 @@ the right-hand column; it is also the answer to "can I delete this one?"
 | ID schemes | `qa-plan`, `qa-cases`, `qa-bind` |
 | Front-matter & format contract | `qa-cases`, `qa-review-cases`, `qa-review-bind` |
 | Connected flow | `qa-bind`, `qa-review-bind` |
-| Binding + run layer | `qa-bind`, `qa-review-bind` |
+| This project's binding + run layer | `qa-bind`, `qa-review-bind` |
 
 **`Paths` is shared in practice.** Other plugins write their own lines into the same section — a
 stories directory, a diagrams directory. Add the test-doc lines in place and leave every other
@@ -126,7 +126,7 @@ creates a fixture; this section is filled in then.
 An empty placeholder block reads as a flow nobody described. One honest line reads as a flow
 that does not exist yet, which is the true state and the one a reviewer can act on.
 
-### Binding + run layer
+### This project's binding + run layer
 
 The concrete commands behind the `qa-*` units' stated intent. **Worth asking about** — the gate
 resolves the audit command from here, so a wrong value fails CI rather than the thing it was


### PR DESCRIPTION
## Summary

- The ownership list in `setup-agent-runner/SKILL.md` named the section **Binding + run layer**; the seed block, and every profile written from it, say **This project's binding + run layer**
- Ownership under `profile-doctrine` → "own only what you read" is enforced by section name, so the unit claimed one name and wrote another
- Also aligned the "Read by" table row and the guidance heading in `profile-sections.md`

Found by the first real run of `setup-agent-runner`, against this repo.

Fixes #96

## Test plan

- [ ] `grep -n "binding + run layer"` across the skill returns only the aligned name and the one prose mention

Generated with [Claude Code](https://claude.com/claude-code)