### PR TITLE
fix(#88): install a project that runs, and prove it with a check

### DIFF
--- a/.github/workflows/install-check.yml
+++ b/.github/workflows/install-check.yml
@@ -1,0 +1,38 @@
+name: Install Check
+
+# Maintainer-only: proves `make install` produces a project that RUNS, not one that
+# merely exists. Deliberately NOT copied into adopting projects — a target has no
+# Makefile install to check (see the Makefile's workflow copy step).
+
+on:
+  workflow_dispatch:
+  workflow_call:
+  pull_request:
+    paths:
+      - "Makefile"
+      - "cicd/tests/**"
+      - "templates/**"
+      - ".github/workflows/install-check.yml"
+  push:
+    branches: [main]
+    paths:
+      - "Makefile"
+      - "cicd/tests/**"
+      - "templates/**"
+
+jobs:
+  install-check:
+    name: Install Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install into a throwaway project and run it
+        run: make check-install

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 #   JUDGE_MODE=dual npm test  # opt in the agent judge
 
 SHELL := /bin/bash
-.PHONY: install help clean check diagrams
+.PHONY: install help clean check check-install diagrams
 
 # Default values
 NAME ?= my-project
@@ -28,6 +28,9 @@ help:
 	@echo "Examples:"
 	@echo "  make install TARGET=/home/user/src/my-app NAME=my-app"
 	@echo "  make install TARGET=../my-project NAME=my-project"
+	@echo ""
+	@echo "Maintainer:"
+	@echo "  make check-install        # install into a temp dir and run it — proves the payload works"
 	@echo ""
 	@echo "Options:"
 	@echo "  TARGET  - Required. Path to your project"
@@ -57,6 +60,8 @@ install: check
 	@# Create directories
 	@mkdir -p "$(TARGET)/cicd/tests/src/judge"
 	@mkdir -p "$(TARGET)/cicd/tests/src/reporter"
+	@mkdir -p "$(TARGET)/cicd/tests/src/mcp/backends"
+	@mkdir -p "$(TARGET)/cicd/tests/scripts"
 	@mkdir -p "$(TARGET)/cicd/tests/testcases/build"
 	@mkdir -p "$(TARGET)/cicd/tests/testcases/integration"
 	@mkdir -p "$(TARGET)/cicd/tests/testcases/e2e"
@@ -70,6 +75,11 @@ install: check
 	@cp "$(TEMPLATE_DIR)/cicd/tests/src/"*.ts "$(TARGET)/cicd/tests/src/"
 	@cp "$(TEMPLATE_DIR)/cicd/tests/src/judge/"*.ts "$(TARGET)/cicd/tests/src/judge/"
 	@cp "$(TEMPLATE_DIR)/cicd/tests/src/reporter/"*.ts "$(TARGET)/cicd/tests/src/reporter/"
+	@# cli.ts imports src/mcp/ unconditionally — omitting it leaves a runner that
+	@# dies on import, and scripts/ backs the check:* and mock-server npm scripts
+	@cp "$(TEMPLATE_DIR)/cicd/tests/src/mcp/"*.ts "$(TARGET)/cicd/tests/src/mcp/"
+	@cp "$(TEMPLATE_DIR)/cicd/tests/src/mcp/backends/"*.ts "$(TARGET)/cicd/tests/src/mcp/backends/"
+	@cp "$(TEMPLATE_DIR)/cicd/tests/scripts/"*.ts "$(TARGET)/cicd/tests/scripts/"
 
 	@# Copy example test cases — from templates/, not this repo's live suite
 	@cp "$(TEMPLATE_DIR)/templates/testcases/build/"*.yml "$(TARGET)/cicd/tests/testcases/build/"
@@ -80,8 +90,12 @@ install: check
 	@cp "$(TEMPLATE_DIR)/cicd/scripts/format-results.sh" "$(TARGET)/cicd/scripts/"
 	@chmod +x "$(TARGET)/cicd/scripts/format-results.sh"
 
-	@# Copy GitHub workflows
-	@cp "$(TEMPLATE_DIR)/.github/workflows/"*.yml "$(TARGET)/.github/workflows/" 2>/dev/null || true
+	@# Copy GitHub workflows — except the ones that test this repo's own installer,
+	@# which have no meaning in a target that has no Makefile install
+	@for f in "$(TEMPLATE_DIR)/.github/workflows/"*.yml; do \
+		case "$$(basename "$$f")" in install-check.yml) continue;; esac; \
+		cp "$$f" "$(TARGET)/.github/workflows/" 2>/dev/null || true; \
+	done
 
 	@# Copy the adopting project's CLAUDE.md — templates/, not this repo's own
 	@if [ -f "$(TEMPLATE_DIR)/templates/CLAUDE.md" ]; then cp "$(TEMPLATE_DIR)/templates/CLAUDE.md" "$(TARGET)/CLAUDE.md"; fi
@@ -124,6 +138,31 @@ install: check
 	@echo "  JUDGE_MODE=dual npm test  # Opt in the agent judge (keyless)"
 	@echo "  npm run list              # List available tests"
 	@echo ""
+
+check-install:
+	@# Proves an install RUNS, rather than proving it was produced. Installs into a
+	@# throwaway dir, checks every npm script's file arrived, then executes the CLI.
+	@set -e; \
+	tmp=$$(mktemp -d); \
+	trap 'rm -rf "$$tmp"' EXIT; \
+	echo "Installing into $$tmp"; \
+	$(MAKE) --no-print-directory install TARGET="$$tmp" NAME=check-install >/dev/null; \
+	cd "$$tmp/cicd/tests"; \
+	echo ""; \
+	echo "1/2 npm scripts reference files the installer copied"; \
+	missing=$$(grep -oE '(src|scripts)/[A-Za-z0-9_./-]+\.ts' package.json | sort -u \
+		| while read -r f; do [ -f "$$f" ] || echo "  $$f"; done); \
+	if [ -n "$$missing" ]; then \
+		echo "FAIL — npm scripts point at files that were not installed:"; \
+		echo "$$missing"; \
+		exit 1; \
+	fi; \
+	echo "    ok"; \
+	echo "2/2 the installed runner executes"; \
+	npm install --silent --no-audit --no-fund; \
+	npx tsx src/cli.ts list; \
+	echo ""; \
+	echo "check-install passed"
 
 diagrams:
 	@docs/diagrams/render.sh

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Other Makefile targets:
 make help                              # show usage
 make clean TARGET=/path/to/project     # remove the framework from a project
 make diagrams                          # re-render docs/diagrams/*.svg → png/
+make check-install                     # install into a temp dir and run it — proves the payload works
 ```
 
 **Agent-driven alternative.** In your project, tell Claude Code `/install /path/to/agent-workflows-runner` (or "Install the test framework from …"). The agent detects your project type, asks a few configuration questions, and installs only what you need with values pre-filled.
@@ -382,6 +383,7 @@ your-project/
 │   │   │   ├── build/           # ← your tests
 │   │   │   ├── integration/
 │   │   │   └── e2e/
+│   │   ├── scripts/             # mock MCP server + the check:* guards
 │   │   ├── package.json
 │   │   └── tsconfig.json
 │   ├── scripts/

--- a/cicd/tests/src/testdoc.ts
+++ b/cicd/tests/src/testdoc.ts
@@ -20,7 +20,7 @@ export interface Scenario {
 }
 
 /** Parse `key: value` front-matter between the first pair of `---` fences. */
-export function parseFrontMatter(md: string): Record<string, string> {
+function parseFrontMatter(md: string): Record<string, string> {
   const m = md.match(/^---\n([\s\S]*?)\n---/);
   const fm: Record<string, string> = {};
   if (!m) return fm;
@@ -51,7 +51,7 @@ export function scenarioFiles(dir: string): string[] {
 }
 
 /** Parse a scenario file into its front-matter and cases (each with its steps). */
-export function parseScenario(md: string): Scenario {
+function parseScenario(md: string): Scenario {
   const frontMatter = parseFrontMatter(md);
   const cases: TestCase[] = [];
 
@@ -90,16 +90,3 @@ export function readScenario(file: string): Scenario {
   return parseScenario(readFileSync(file, 'utf8'));
 }
 
-/** The searchable step text for one row: "Action — Expected" (or just Action). */
-export function stepText(s: { action: string; expected: string }): string {
-  return s.expected && s.expected !== '—' ? `${s.action} — ${s.expected}` : s.action;
-}
-
-/**
- * The searchable text for a case-level row: its title and objective — *what the
- * case verifies*, the level an agent searches by. Falls back to the title alone
- * when a case has no objective.
- */
-export function caseText(c: { title: string; objective: string | null }): string {
-  return c.objective ? `${c.title} — ${c.objective}` : c.title;
-}


### PR DESCRIPTION
## Summary

- `make install` never copied `src/mcp/`, which `cli.ts:19-20` imports unconditionally — every installed project died on import before a single test executed. Three npm scripts had the same shape, pointing at `cicd/tests/scripts/`, also never copied
- `make check-install` installs into a throwaway dir and **exercises** the result: every npm script's referenced file must be present, then the installed CLI must actually run
- `install-check.yml` runs it on PRs and pushes touching the payload
- Folds in #94: `testdoc`'s dead exports removed

Fixes #88
Fixes #94

## The check can fail

A smoke check that always passes is worthless, so both gates were verified against the original defects reintroduced in a scratch install:

| Gate | Defect reintroduced | Result |
|---|---|---|
| npm scripts' files present | `rm -rf scripts/` | caught all three: `check-mcp-host.ts`, `check-mcp-test.ts`, `check-verifier-helpers.ts` |
| installed runner executes | `rm -rf src/mcp/` | `ERR_MODULE_NOT_FOUND ... src/mcp/test-mcp.js`, exit 1 — the exact error #88 reports |

## One trap worth naming

`ci.yml` **is** copied into adopting projects. Wiring the install check in as a job there would leave every target with a pipeline referencing a workflow that was never copied — the same bug class this PR fixes. So `install-check.yml` stands alone with its own triggers and is explicitly excluded from the copy step.

## Deliberately not here

The `ollama37` dual-judge evidence run and the README's "AI-produced content testing & audit" row it backs — split to #98. It needs a reachable model host, and a dead-on-arrival installer should not sit behind infrastructure.

## Test plan

- [x] `make check-install` passes — installed project lists 4 example cases
- [x] both gates fail on their reintroduced defect
- [x] `npm run build` (tsc) clean; `audit-bind` exit 0; `port-yaml` emits a scaffold
- [ ] `install-check.yml` goes green on this PR

Generated with [Claude Code](https://claude.com/claude-code)