### PR TITLE
fix(#100): declare the triage state label in the profile

### DIFF
--- a/.claude/rules/project-profile.md
+++ b/.claude/rules/project-profile.md
@@ -52,7 +52,9 @@ project's choice.
 - test plan: `test-plan` (`#006b75`)
 - priority: `priority:high` · `priority:medium` · `priority:low`
 - type: `feature` · `enhancement` · `bug` · `docs`
-- status: `status:in-progress` · `status:needs-review` · `status:blocked`
+- status (pipeline position): `status:in-progress` · `status:needs-review` · `status:blocked`
+- triage state (readiness): `ready-for-agent` — applied upstream, and `ship-merge` is its only
+  exit. The five canonical roles and this project's strings: `docs/agents/triage-labels.md`
 
 ## Linking & branch
 


### PR DESCRIPTION
## Summary

- `project-profile.md` → Labels now declares `triage state: ready-for-agent`, sourced from `docs/agents/triage-labels.md`
- Labels the two kinds explicitly — status is *pipeline position*, triage state is *readiness* — since `ship-merge` clears both for different reasons
- No colour declared: this plugin only **clears** that label, and creation belongs where a label is applied (`ship-tail` → Who creates a label). Declaring a colour here would let `--force` overwrite a downstream's choice
- `ready-for-agent` cleared from the already-closed #88 by hand

Fixes #100

## Why it took three merges to fix

Raised at the gate on #95, #97 and #99. The first two were harmless — neither issue carried a triage label, so nothing was stranded. #99 was the one that bit: #88 carried `ready-for-agent`, and `ship-merge` is that label's only exit.

## Test plan

- [ ] The next `/ship-merge` resolves both label names and clears both with no gate finding

Generated with [Claude Code](https://claude.com/claude-code)